### PR TITLE
Add human-friendly error when decryption fails

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
 ## Planned (Unreleased)
+## v2.4.1 / 2015-02-05
+* when decrypting, if the vault is encrypted for the node but decryption fails, emit a more friendly error message than 'OpenSSL::PKey::RSAError: padding check failed'
 
 ## Released
 ## v2.4.0 / 2014-12-03

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Author:: Kevin Moser - @moserke<br>
 Author:: Eli Klein - @eliklein<br>
 Author:: Joey Geiger - @jgeiger<br>
 Author:: Joshua Timberman - @jtimberman<br>
+Author:: James FitzGibbon - @jf647<br>
 
 ## Contributors
 

--- a/features/step_definitions/chef-repo.rb
+++ b/features/step_definitions/chef-repo.rb
@@ -1,4 +1,4 @@
-Given /^a local mode chef repo with nodes '(.+)'$/ do |nodelist|
+Given(/^a local mode chef repo with nodes '(.+)'$/) do |nodelist|
   # create the repo directory hierarchy
   %w(cookbooks clients nodes data_bags).each do |dir|
     create_dir dir
@@ -11,7 +11,7 @@ chef_zero.enabled true
 EOF
   # create the admin user and capture its private key
   in_current_dir do
-      system 'knife client create admin -z -d -a -c knife.rb > admin.pem'
+    create_admin
   end
   # add the admin key to the knife configuration
   append_to_file 'knife.rb', <<EOF
@@ -20,14 +20,40 @@ client_key 'admin.pem'
 EOF
   # create the requested nodes
   nodelist.split(/,/).each do |node|
-    run_simple "knife client create #{node} -z -d -c knife.rb"
-    run_simple "knife node create #{node} -z -d -c knife.rb"
+    in_current_dir do
+      create_client(node)
+      create_node(node)
+    end
   end
 end
 
-When /^I delete clients? '(.+)' from the Chef server$/ do |nodelist|
+Given(/^I delete clients? '(.+)' from the Chef server$/) do |nodelist|
   nodelist.split(/,/).each do |node|
-    run_simple "knife client delete #{node} -z -d -y -c knife.rb"
+    in_current_dir do
+      delete_client(node)
+    end
   end
 end
 
+Given(/^I regenerate the client key for the node '(.+)'$/) do |node|
+  in_current_dir do
+    delete_client(node)
+    create_client(node)
+  end
+end
+
+def create_node(name)
+  system "knife node create #{name} -z -d -c knife.rb"
+end
+
+def create_admin
+  create_client('admin', '-a')
+end
+
+def create_client(name, args = nil)
+  system "knife client create #{name} -z -d -c knife.rb #{args} > #{name}.pem"
+end
+
+def delete_client(name)
+  system "knife client delete #{name} -y -z"
+end

--- a/features/step_definitions/chef-vault.rb
+++ b/features/step_definitions/chef-vault.rb
@@ -28,7 +28,7 @@ Given(/^I rotate all keys with the '(.+)' options?$/) do |optionlist|
 end
 
 Given(/^I try to decrypt the vault item '(.+)\/(.+)' as '(.+)'$/) do |vault, item, node|
-  run_simple "knife vault show #{vault} #{item} -z -c knife.rb -u #{node} -k #{node}.pem"
+  run_simple "knife vault show #{vault} #{item} -z -c knife.rb -u #{node} -k #{node}.pem", false
 end
 
 Then(/^the vault item '(.+)\/(.+)' should( not)? be encrypted for '(.+)'$/) do |vault, item, neg, nodelist|

--- a/features/step_definitions/chef-vault.rb
+++ b/features/step_definitions/chef-vault.rb
@@ -1,33 +1,37 @@
 require 'json'
 
-When /^I create a vault item '(.+)\/(.+)' containing the JSON '(.+)' encrypted for '(.+)'$/ do |vault, item, json, nodelist|
+Given(/^I create a vault item '(.+)\/(.+)' containing the JSON '(.+)' encrypted for '(.+)'$/) do |vault, item, json, nodelist|
   write_file 'item.json', json
   query = nodelist.split(/,/).map{|e| "name:#{e}"}.join(' OR ')
   run_simple "knife vault create #{vault} #{item} -z -c knife.rb -A admin -S '#{query}' -J item.json"
 end
 
-When /^I update the vault item '(.+)\/(.+)' to be encrypted for '(.+)'( with the clean option)?$/ do |vault, item, nodelist, cleanopt|
+Given(/^I update the vault item '(.+)\/(.+)' to be encrypted for '(.+)'( with the clean option)?$/) do |vault, item, nodelist, cleanopt|
   query = nodelist.split(/,/).map{|e| "name:#{e}"}.join(' OR ')
-  run_simple "knife vault update #{vault} #{item} -S '#{query}' #{cleanopt ? '--clean' : ''}"
+  run_simple "knife vault update #{vault} #{item} -z -c knife.rb -S '#{query}' #{cleanopt ? '--clean' : ''}"
 end
 
-When /^I remove clients? '(.+)' from vault item '(.+)\/(.+)' with the '(.+)' options?$/ do |nodelist, vault, item, optionlist|
+Given(/^I remove clients? '(.+)' from vault item '(.+)\/(.+)' with the '(.+)' options?$/) do |nodelist, vault, item, optionlist|
   query = nodelist.split(/,/).map{|e| "name:#{e}"}.join(' OR ')
   options = optionlist.split(/,/).map{|o| "--#{o}"}.join(' ')
-  run_simple "knife vault remove #{vault} #{item} -S '#{query}' #{options}"
+  run_simple "knife vault remove #{vault} #{item} -z -c knife.rb -S '#{query}' #{options}"
 end
 
-When /^I rotate the keys for vault item '(.+)\/(.+)' with the '(.+)' options?$/ do |vault, item, optionlist|
+Given(/^I rotate the keys for vault item '(.+)\/(.+)' with the '(.+)' options?$/) do |vault, item, optionlist|
   options = optionlist.split(/,/).map{|o| "--#{o}"}.join(' ')
-  run_simple "knife vault rotate keys #{vault} #{item} #{options}"
+  run_simple "knife vault rotate keys #{vault} #{item} -c knife.rb -z #{options}"
 end
 
-When /^I rotate all keys with the '(.+)' options?$/ do |optionlist|
+Given(/^I rotate all keys with the '(.+)' options?$/) do |optionlist|
   options = optionlist.split(/,/).map{|o| "--#{o}"}.join(' ')
-  run_simple "knife vault rotate all keys #{options}"
+  run_simple "knife vault rotate all keys -z -c knife.rb #{options}"
 end
 
-Then /^the vault item '(.+)\/(.+)' should( not)? be encrypted for '(.+)'$/ do |vault, item, neg, nodelist|
+Given(/^I try to decrypt the vault item '(.+)\/(.+)' as '(.+)'$/) do |vault, item, node|
+  run_simple "knife vault show #{vault} #{item} -z -c knife.rb -u #{node} -k #{node}.pem"
+end
+
+Then(/^the vault item '(.+)\/(.+)' should( not)? be encrypted for '(.+)'$/) do |vault, item, neg, nodelist|
   nodes = nodelist.split(/,/)
   run_simple("knife vault show #{vault} #{item} -z -c knife.rb -p clients -F json")
   output = output_from("knife vault show #{vault} #{item} -z -c knife.rb -p clients -F json")

--- a/features/wrong_private_key.feature
+++ b/features/wrong_private_key.feature
@@ -11,4 +11,4 @@ Feature: Wrong private key during decrypt
     And I create a vault item 'test/item' containing the JSON '{"foo": "bar"}' encrypted for 'one,two'
     And I regenerate the client key for the node 'one'
     And I try to decrypt the vault item 'test/item' as 'one'
-    Then the output should match /unable to decrypt item as 'one'/
+    Then the output should match /is encrypted for you, but your private key failed to decrypt the contents/

--- a/features/wrong_private_key.feature
+++ b/features/wrong_private_key.feature
@@ -1,0 +1,14 @@
+Feature: Wrong private key during decrypt
+
+  https://github.com/Nordstrom/chef-vault/issues/43
+  If a vault is encrypted for a node and then the node's private
+  key is regenerated, the error that comes back from chef-vault
+  should be informative, not a lower-level error from OpenSSL
+  like 'OpenSSL::PKey::RSAError: padding check failed'
+
+  Scenario: Regenerate node key and attempt decrypt
+    Given a local mode chef repo with nodes 'one,two'
+    And I create a vault item 'test/item' containing the JSON '{"foo": "bar"}' encrypted for 'one,two'
+    And I regenerate the client key for the node 'one'
+    And I try to decrypt the vault item 'test/item' as 'one'
+    Then the output should match /unable to decrypt item as 'one'/

--- a/lib/chef-vault/version.rb
+++ b/lib/chef-vault/version.rb
@@ -14,6 +14,6 @@
 # limitations under the License.
 
 class ChefVault
-  VERSION = "2.4.0"
+  VERSION = "2.4.1"
   MAJOR, MINOR, TINY = VERSION.split('.')
 end


### PR DESCRIPTION
Emit a human friendly error message when there is an encrypted shared secret for the node, but decryption using the node's private key fails.

Closes #43