### PR TITLE
Skip and warn for broken nodes that lack a public key

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
 ## Planned (Unreleased)
+## v2.4.1 / 2015-02-05
+* when attempting to add a client key to a vault item, warn and skip if the node doesn't have a public key (reported by Nik Ormseth)
 
 ## Released
 ## v2.4.0 / 2014-12-03

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Contributor:: Reto Hermann
 
 ## License
 
-Copyright:: Copyright (c) 2013-14 Nordstrom, Inc.<br>
+Copyright:: Copyright (c) 2013-15 Nordstrom, Inc.<br>
 License:: Apache License, Version 2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/chef-vault
+++ b/bin/chef-vault
@@ -3,15 +3,15 @@
 # ./chef-vault - Run chef-vault and decrypt based on parameters
 #
 # Author:: Kevin Moser (<kevin.moser@nordstrom.com>)
-# Copyright:: Copyright (c) 2013 Nordstrom, Inc.
+# Copyright:: Copyright (c) 2013-15 Nordstrom, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,7 +34,7 @@ options_config = {
     description: "Vault to look in",
     default: nil,
     optional: false
-  },  
+  },
   item: {
     short: "i",
     long: "item",
@@ -57,7 +57,7 @@ options_config.each do |option, config|
     banner << "[--#{config[:long]} #{config[:long].upcase}] "
   else
     banner << "--#{config[:long]} #{config[:long].upcase} "
-  end    
+  end
 end
 
 options = {}

--- a/chef-vault.gemspec
+++ b/chef-vault.gemspec
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 # Chef-Vault Gemspec file
-# Copyright 2013, Nordstrom, Inc.
+# Copyright 2013-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/chef-vault.gemspec
+++ b/chef-vault.gemspec
@@ -38,7 +38,15 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.1'
   s.add_development_dependency 'rspec-its', '~> 1.1'
   s.add_development_dependency 'aruba', '~> 0.6'
-  s.add_development_dependency 'chef', '>= 0.10.10'
   s.add_development_dependency 'simplecov', '~> 0.9'
   s.add_development_dependency 'simplecov-console', '~> 0.2'
+  # Chef 12 and higher pull in Ohai 8, which needs Ruby v2
+  # so only in the case of a CI build on ruby v1, we constrain
+  # chef to 11 or lower so that we can maintain CI test coverage
+  # of older versions
+  if ENV.key?('TRAVIS_BUILD') && RUBY_VERSION =~ /^1/
+    s.add_development_dependency 'chef', '~> 11.18'
+  else
+    s.add_development_dependency 'chef', '>= 0.10.10'
+  end
 end

--- a/lib/chef-vault/certificate.rb
+++ b/lib/chef-vault/certificate.rb
@@ -1,5 +1,5 @@
 # Description: ChefVault::Certificate class
-# Copyright 2013, Nordstrom, Inc.
+# Copyright 2013-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef-vault/exceptions.rb
+++ b/lib/chef-vault/exceptions.rb
@@ -1,5 +1,5 @@
 # Author:: Kevin Moser <kevin.moser@nordstrom.com>
-# Copyright:: Copyright 2013, Nordstrom, Inc.
+# Copyright:: Copyright 2013-15, Nordstrom, Inc.
 # License:: Apache License, Version 2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef-vault/item.rb
+++ b/lib/chef-vault/item.rb
@@ -1,5 +1,5 @@
 # Author:: Kevin Moser <kevin.moser@nordstrom.com>
-# Copyright:: Copyright 2013, Nordstrom, Inc.
+# Copyright:: Copyright 2013-15, Nordstrom, Inc.
 # License:: Apache License, Version 2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,7 +44,11 @@ class ChefVault::Item < Chef::DataBagItem
 
         case action
         when :add
-          keys.add(load_client(node.name), @secret, "clients")
+          begin
+            keys.add(load_client(node.name), @secret, "clients")
+          rescue ChefVault::Exceptions::ClientNotFound => e
+            $stderr.puts "node '#{node.name}' has no private key; skipping"
+          end
         when :delete
           keys.delete(node.name, "clients")
         else

--- a/lib/chef-vault/item_keys.rb
+++ b/lib/chef-vault/item_keys.rb
@@ -1,5 +1,5 @@
 # Author:: Kevin Moser <kevin.moser@nordstrom.com>
-# Copyright:: Copyright 2013, Nordstrom, Inc.
+# Copyright:: Copyright 2013-15, Nordstrom, Inc.
 # License:: Apache License, Version 2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef-vault/user.rb
+++ b/lib/chef-vault/user.rb
@@ -1,5 +1,5 @@
 # Description: ChefVault::User class
-# Copyright 2013, Nordstrom, Inc.
+# Copyright 2013-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef-vault/version.rb
+++ b/lib/chef-vault/version.rb
@@ -1,5 +1,5 @@
 # Description: ChefVault VERSION file
-# Copyright 2013, Nordstrom, Inc.
+# Copyright 2013-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
 # limitations under the License.
 
 class ChefVault
-  VERSION = "2.4.0"
+  VERSION = "2.4.1"
   MAJOR, MINOR, TINY = VERSION.split('.')
 end

--- a/lib/chef/knife/decrypt.rb
+++ b/lib/chef/knife/decrypt.rb
@@ -1,5 +1,5 @@
 # Description: Chef-Vault Decrypt class
-# Copyright 2013, Nordstrom, Inc.
+# Copyright 2013-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/knife/encrypt_create.rb
+++ b/lib/chef/knife/encrypt_create.rb
@@ -1,5 +1,5 @@
 # Description: Chef-Vault EncryptCreate class
-# Copyright 2013, Nordstrom, Inc.
+# Copyright 2013-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/knife/encrypt_delete.rb
+++ b/lib/chef/knife/encrypt_delete.rb
@@ -1,5 +1,5 @@
 # Description: Chef-Vault EncryptDelete class
-# Copyright 2013, Nordstrom, Inc.
+# Copyright 2013-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/knife/encrypt_remove.rb
+++ b/lib/chef/knife/encrypt_remove.rb
@@ -1,5 +1,5 @@
 # Description: Chef-Vault EncryptRemove class
-# Copyright 2013, Nordstrom, Inc.
+# Copyright 2013-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/knife/encrypt_rotate_keys.rb
+++ b/lib/chef/knife/encrypt_rotate_keys.rb
@@ -1,5 +1,5 @@
 # Description: Chef-Vault EncryptRotateKeys class
-# Copyright 2013, Nordstrom, Inc.
+# Copyright 2013-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/knife/encrypt_update.rb
+++ b/lib/chef/knife/encrypt_update.rb
@@ -1,5 +1,5 @@
 # Description: Chef-Vault EncryptUpdate class
-# Copyright 2013, Nordstrom, Inc.
+# Copyright 2013-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/knife/vault_admins.rb
+++ b/lib/chef/knife/vault_admins.rb
@@ -1,5 +1,5 @@
 # Description: Chef-Vault VaultAdmins module
-# Copyright 2014, Nordstrom, Inc.
+# Copyright 2014-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/knife/vault_base.rb
+++ b/lib/chef/knife/vault_base.rb
@@ -1,5 +1,5 @@
 # Description: Chef-Vault VaultBase module
-# Copyright 2013, Nordstrom, Inc.
+# Copyright 2013-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/knife/vault_create.rb
+++ b/lib/chef/knife/vault_create.rb
@@ -1,5 +1,5 @@
 # Description: Chef-Vault VaultCreate class
-# Copyright 2014, Nordstrom, Inc.
+# Copyright 2014-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/knife/vault_decrypt.rb
+++ b/lib/chef/knife/vault_decrypt.rb
@@ -1,5 +1,5 @@
 # Description: Chef-Vault VaultDecrypt class
-# Copyright 2013, Nordstrom, Inc.
+# Copyright 2013-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/knife/vault_delete.rb
+++ b/lib/chef/knife/vault_delete.rb
@@ -1,5 +1,5 @@
 # Description: Chef-Vault VaultDelete class
-# Copyright 2013, Nordstrom, Inc.
+# Copyright 2013-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/knife/vault_download.rb
+++ b/lib/chef/knife/vault_download.rb
@@ -1,5 +1,5 @@
 # Description: Chef-Vault VaultDownload class
-# Copyright 2014, Nordstrom, Inc.
+# Copyright 2014-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/knife/vault_edit.rb
+++ b/lib/chef/knife/vault_edit.rb
@@ -1,5 +1,5 @@
 # Description: Chef-Vault VaultEdit class
-# Copyright 2013, Nordstrom, Inc.
+# Copyright 2013-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/knife/vault_refresh.rb
+++ b/lib/chef/knife/vault_refresh.rb
@@ -1,5 +1,5 @@
 # Description: Chef-Vault VaultReapply class
-# Copyright 2013, Nordstrom, Inc.
+# Copyright 2013-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/knife/vault_remove.rb
+++ b/lib/chef/knife/vault_remove.rb
@@ -1,5 +1,5 @@
 # Description: Chef-Vault VaultRemove class
-# Copyright 2013, Nordstrom, Inc.
+# Copyright 2013-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/knife/vault_rotate_all_keys.rb
+++ b/lib/chef/knife/vault_rotate_all_keys.rb
@@ -1,5 +1,5 @@
 # Description: Chef-Vault VaultRotateAllKeys class
-# Copyright 2013, Nordstrom, Inc.
+# Copyright 2013-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/knife/vault_rotate_keys.rb
+++ b/lib/chef/knife/vault_rotate_keys.rb
@@ -1,5 +1,5 @@
 # Description: Chef-Vault VaultRotateKeys class
-# Copyright 2013, Nordstrom, Inc.
+# Copyright 2013-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/knife/vault_show.rb
+++ b/lib/chef/knife/vault_show.rb
@@ -1,5 +1,5 @@
 # Description: Chef-Vault VaultShow class
-# Copyright 2013, Nordstrom, Inc.
+# Copyright 2013-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/knife/vault_update.rb
+++ b/lib/chef/knife/vault_update.rb
@@ -1,5 +1,5 @@
 # Description: Chef-Vault VaultUpdate class
-# Copyright 2014, Nordstrom, Inc.
+# Copyright 2014-15, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/chef-vault/item_spec.rb
+++ b/spec/chef-vault/item_spec.rb
@@ -1,3 +1,55 @@
+require 'openssl'
+require 'rspec/core/shared_context'
+
+# it turns out that simulating a node that doesn't have a public
+# key is not a simple thing
+module BorkedNodeWithoutPublicKey
+  extend RSpec::Core::SharedContext
+
+  before do
+    # a node 'foo' with a public key
+    node_foo = double('chef node foo')
+    allow(node_foo).to receive(:name).and_return('foo')
+    client_foo = double('chef apiclient foo')
+    allow(client_foo).to receive(:name).and_return('foo')
+    privkey = OpenSSL::PKey::RSA.new(1024)
+    pubkey = privkey.public_key
+    allow(client_foo).to receive(:public_key).and_return(pubkey.to_pem)
+    # a node 'bar' without a public key
+    node_bar = double('chef node bar')
+    allow(node_bar).to receive(:name).and_return('bar')
+    # fake out searches to return both of our nodes
+    query_result = double('chef search results')
+    allow(query_result)
+      .to receive(:search)
+      .with(Symbol, String)
+      .and_return([[node_foo, node_bar]])
+    allow(Chef::Search::Query)
+      .to receive(:new)
+      .and_return(query_result)
+    # create a new vault item
+    @vaultitem = ChefVault::Item.new('foo', 'bar')
+    @vaultitem['foo'] = 'bar'
+    # make the vault item return the apiclient for foo but raise for bar
+    allow(@vaultitem).to receive(:load_client).with('foo')
+      .and_return(client_foo)
+    allow(@vaultitem).to receive(:load_client).with('bar')
+      .and_raise(ChefVault::Exceptions::ClientNotFound)
+    # make the vault item fall back to 'load-admin-as-client' behaviour
+    http_response = double('http not found')
+    allow(http_response).to receive(:code).and_return('404')
+    http_not_found = Net::HTTPServerException.new('not found', http_response)
+    allow(ChefVault::ChefPatch::User)
+      .to receive(:load)
+      .with('foo')
+      .and_return(client_foo)
+    allow(ChefVault::ChefPatch::User)
+      .to receive(:load)
+      .with('bar')
+      .and_raise(http_not_found)
+  end
+end
+
 RSpec.describe ChefVault::Item do
   subject(:item) { ChefVault::Item.new("foo", "bar") }
 
@@ -21,6 +73,35 @@ RSpec.describe ChefVault::Item do
       let(:item) { ChefVault::Item.new("foo", "bar.bar") }
 
       specify { expect { item.save }.to raise_error }
+    end
+  end
+
+  describe '#clients' do
+    include BorkedNodeWithoutPublicKey
+
+    it 'should not blow up when search returns a node without a public key' do
+      # try to set clients when we know a node is missing a public key
+      # this should not die as of v2.4.1
+      expect {
+        @vaultitem.clients('*:*')
+      }.not_to raise_error
+    end
+
+    it 'should emit a warning if search returns a node without a public key' do
+      # it should however emit a warning that you have a borked node
+      expect {
+        @vaultitem.clients('*:*')
+      }.to output(/node 'bar' has no private key; skipping/).to_stderr
+    end
+  end
+
+  describe '#admins' do
+    include BorkedNodeWithoutPublicKey
+
+    it 'should blow up if you try to use a node without a public key as an admin' do
+      expect {
+        @vaultitem.admins('foo,bar')
+      }.to raise_error(ChefVault::Exceptions::AdminNotFound)
     end
   end
 end


### PR DESCRIPTION
When attempting to add a client key to a vault item, warn and skip if the node doesn't have a public key

Closes #127 