### PR TITLE
Fix inability to clean client when the node object has gone away

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
 ## Planned (Unreleased)
+## v2.5.0 / 2015-02-05
+* fix a problem with the --clean-unknown-clients switch to `rotate keys` that made it impossible to delete a client that could not be searched for (i.e. the node object is deleted)
 
 ## Released
 ## v2.4.0 / 2014-12-03

--- a/features/clean_unknown_clients.feature
+++ b/features/clean_unknown_clients.feature
@@ -15,6 +15,9 @@ Feature: clean unknown clients on key rotation
     And I delete client 'one' from the Chef server
     And I remove client 'two' from vault item 'test/item' with the 'clean-unknown-clients' option
     Then the vault item 'test/item' should be encrypted for 'three'
+    And the vault item 'test/item' should not be encrypted for 'two'
+    And 'three' should be a client for the vault item 'test/item'
+    And 'two' should not be a client for the vault item 'test/item'
 
   Scenario: Prune clients when rotating keys
     Given a local mode chef repo with nodes 'one,two,three'
@@ -23,6 +26,9 @@ Feature: clean unknown clients on key rotation
     And I delete client 'one' from the Chef server
     And I rotate the keys for vault item 'test/item' with the 'clean-unknown-clients' option
     Then the vault item 'test/item' should be encrypted for 'two,three'
+    And the vault item 'test/item' should not be encrypted for 'one'
+    And 'two,three' should be a client for the vault item 'test/item'
+    And 'one' should not be a client for the vault item 'test/item'
 
   Scenario: Prune clients when rotating all keys
     Given a local mode chef repo with nodes 'one,two,three'
@@ -31,3 +37,17 @@ Feature: clean unknown clients on key rotation
     And I delete clients 'one,two' from the Chef server
     And I rotate all keys with the 'clean-unknown-clients' option
     Then the vault item 'test/item' should be encrypted for 'three'
+    And the vault item 'test/item' should not be encrypted for 'one,two'
+    And 'three' should be a client for the vault item 'test/item'
+    And 'one,two' should not be a client for the vault item 'test/item'
+
+  Scenario: Prune clients when node gone but client exists
+    Given a local mode chef repo with nodes 'one,two,three'
+    And I create a vault item 'test/item' containing the JSON '{"foo": "bar"}' encrypted for 'one,two,three'
+    Then the vault item 'test/item' should be encrypted for 'one,two,three'
+    And I delete node 'one' from the Chef server
+    And I rotate the keys for vault item 'test/item' with the 'clean-unknown-clients' option
+    Then the vault item 'test/item' should be encrypted for 'two,three'
+    And the vault item 'test/item' should not be encrypted for 'one'
+    And 'two,three' should be a client for the vault item 'test/item'
+    And 'one' should not be a client for the vault item 'test/item'

--- a/features/clean_unknown_clients.feature
+++ b/features/clean_unknown_clients.feature
@@ -14,10 +14,11 @@ Feature: clean unknown clients on key rotation
     Then the vault item 'test/item' should be encrypted for 'one,two,three'
     And I delete client 'one' from the Chef server
     And I remove client 'two' from vault item 'test/item' with the 'clean-unknown-clients' option
-    Then the vault item 'test/item' should be encrypted for 'three'
-    And the vault item 'test/item' should not be encrypted for 'two'
+    Then the output should contain "Removing unknown client 'one'"
+    And the vault item 'test/item' should be encrypted for 'three'
+    And the vault item 'test/item' should not be encrypted for 'one,two'
     And 'three' should be a client for the vault item 'test/item'
-    And 'two' should not be a client for the vault item 'test/item'
+    And 'one,two' should not be a client for the vault item 'test/item'
 
   Scenario: Prune clients when rotating keys
     Given a local mode chef repo with nodes 'one,two,three'
@@ -25,7 +26,8 @@ Feature: clean unknown clients on key rotation
     Then the vault item 'test/item' should be encrypted for 'one,two,three'
     And I delete client 'one' from the Chef server
     And I rotate the keys for vault item 'test/item' with the 'clean-unknown-clients' option
-    Then the vault item 'test/item' should be encrypted for 'two,three'
+    Then the output should contain "Removing unknown client 'one'"
+    And the vault item 'test/item' should be encrypted for 'two,three'
     And the vault item 'test/item' should not be encrypted for 'one'
     And 'two,three' should be a client for the vault item 'test/item'
     And 'one' should not be a client for the vault item 'test/item'
@@ -36,7 +38,9 @@ Feature: clean unknown clients on key rotation
     Then the vault item 'test/item' should be encrypted for 'one,two,three'
     And I delete clients 'one,two' from the Chef server
     And I rotate all keys with the 'clean-unknown-clients' option
-    Then the vault item 'test/item' should be encrypted for 'three'
+    Then the output should contain "Removing unknown client 'one'"
+    And the output should contain "Removing unknown client 'two'"
+    And the vault item 'test/item' should be encrypted for 'three'
     And the vault item 'test/item' should not be encrypted for 'one,two'
     And 'three' should be a client for the vault item 'test/item'
     And 'one,two' should not be a client for the vault item 'test/item'
@@ -47,7 +51,8 @@ Feature: clean unknown clients on key rotation
     Then the vault item 'test/item' should be encrypted for 'one,two,three'
     And I delete node 'one' from the Chef server
     And I rotate the keys for vault item 'test/item' with the 'clean-unknown-clients' option
-    Then the vault item 'test/item' should be encrypted for 'two,three'
+    Then the output should contain "Removing unknown client 'one'"
+    And the vault item 'test/item' should be encrypted for 'two,three'
     And the vault item 'test/item' should not be encrypted for 'one'
     And 'two,three' should be a client for the vault item 'test/item'
     And 'one' should not be a client for the vault item 'test/item'

--- a/features/step_definitions/chef-repo.rb
+++ b/features/step_definitions/chef-repo.rb
@@ -31,3 +31,8 @@ When /^I delete clients? '(.+)' from the Chef server$/ do |nodelist|
   end
 end
 
+Given(/^I delete nodes? '(.+)' from the Chef server$/) do |nodelist|
+  nodelist.split(/,/).each do |node|
+    run_simple "knife node delete #{node} -z -d -y -c knife.rb"
+  end
+end

--- a/features/step_definitions/chef-vault.rb
+++ b/features/step_definitions/chef-vault.rb
@@ -29,13 +29,45 @@ end
 
 Then /^the vault item '(.+)\/(.+)' should( not)? be encrypted for '(.+)'$/ do |vault, item, neg, nodelist|
   nodes = nodelist.split(/,/)
-  run_simple("knife vault show #{vault} #{item} -z -c knife.rb -p clients -F json")
-  output = output_from("knife vault show #{vault} #{item} -z -c knife.rb -p clients -F json")
+  command = "knife data bag show #{vault} #{item}_keys -z -c knife.rb -F json"
+  run_simple(command)
+  output = stdout_from(command)
+  data = JSON.parse(output)
   nodes.each do |node|
     if neg
-      assert_no_partial_output(node, output)
+      expect(data).not_to include(node)
     else
-      assert_partial_output(node, output)
+      expect(data).to include(node)
+    end
+  end
+end
+
+Given(/^'(.+)' should( not)? be a client for the vault item '(.+)\/(.+)'$/) do |nodelist, neg, vault, item|
+  nodes = nodelist.split(/,/)
+  command = "knife data bag show #{vault} #{item}_keys -z -c knife.rb -F json"
+  run_simple(command)
+  output = stdout_from(command)
+  data = JSON.parse(output)
+  nodes.each do |node|
+    if neg
+      expect(data['clients']).not_to include(node)
+    else
+      expect(data['clients']).to include(node)
+    end
+  end
+end
+
+Given(/^'(.+)' should( not)? be an admin for the vault item '(.+)\/(.+)'$/) do |nodelist, neg, vault, item|
+  nodes = nodelist.split(/,/)
+  command = "knife data bag show #{vault} #{item}_keys -z -c knife.rb -F json"
+  run_simple(command)
+  output = stdout_from(command)
+  data = JSON.parse(output)
+  nodes.each do |node|
+    if neg
+      expect(data['admins']).not_to include(node)
+    else
+      expect(data['admins']).to include(node)
     end
   end
 end

--- a/lib/chef-vault/version.rb
+++ b/lib/chef-vault/version.rb
@@ -14,6 +14,6 @@
 # limitations under the License.
 
 class ChefVault
-  VERSION = "2.4.0"
+  VERSION = "2.5.0"
   MAJOR, MINOR, TINY = VERSION.split('.')
 end


### PR DESCRIPTION
Fixes issue #133 - the original implementation worked if the client was missing but the node still existed, but not the other way around.

@thg65, you might want to take a look at this since you contributed the original implementation of `--clean-unknown-clients`
