### PR TITLE
Update docs to reflect the new compile_time attribute of chef_gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,13 +145,21 @@ NOTE: chef-vault 1.0 style decryption is supported, however it has been deprecat
 ### Example Code
 
 ```ruby
-chef_gem "chef-vault"
+chef_gem 'chef-vault' do
+  compile_time true if respond_to?(:compile_time)
+end
 
 require 'chef-vault'
 
 item = ChefVault::Item.load("passwords", "root")
 item["password"]
 ```
+
+Note that in this case, the gem needs to be installed at compile time
+because the require statement is at the top-level of the recipe.  If
+you move the require of chef-vault and the call to `::load` to
+library or provider code, you can install the gem in the converge phase
+instead.
 
 ## USAGE STAND ALONE
 

--- a/THEORY.md
+++ b/THEORY.md
@@ -231,7 +231,9 @@ the server 'one'.
 
 Assuming that the recipe contains code such as this:
 
-    chef_gem 'chef-vault'
+    chef_gem 'chef-vault' do
+      compile_time true if respond_to?(:compile_time)
+    end
     require 'chef-vault'
     vaultitem = ChefVault::Item.load('foo', 'bar')
 


### PR DESCRIPTION
Update docs to reflect the new compile_time attribute of chef_gem required to suppress warnings in Chef 12.1.0.
Closes #143
[ciskip]