### PR TITLE
Allow ruby 1.9.3 to fail on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-  - "1.9.3-p551"
-  - "2.0.0-p598"
-  - "2.1.5"
+  - "2.0.0-p645"
+  - "2.1.6"
+  - "2.2.2"
 install: bundle install --binstubs
 env: TRAVIS_BUILD=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: ruby
 rvm:
-  - "2.0.0-p645"
+  - "1.9.3-p551"
+  - "2.0.0-p598"
   - "2.1.6"
   - "2.2.2"
 install: bundle install --binstubs
 env: TRAVIS_BUILD=true
+matrix:
+  allow_failures:
+    - rvm: "1.9.3-p551"

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,9 +3,8 @@
 
 This release will focus on adding any new features covered by open issues
 
-* remove Ruby 1.9.3 from version matrix on Travis\
- * failures were causing the overall build state badge to fail
- * Ruby 1.9.3 is no longer supported (https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended/)
+* allow Ruby 1.9.3 failures to not cause the overall build to fail on Travis
+* switch to latest 2.0.x, 2.1.x, and 2.2.x releases of Ruby
 
 ## v2.7.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,10 @@
 
 This release will focus on adding any new features covered by open issues
 
+* remove Ruby 1.9.3 from version matrix on Travis\
+ * failures were causing the overall build state badge to fail
+ * Ruby 1.9.3 is no longer supported (https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended/)
+
 ## v2.7.0
 
 This release will focus on reducing tech debt:


### PR DESCRIPTION
without failing the entire build