### PR TITLE
Add a #raw_keys method to ChefVault::Item

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,7 +16,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 281
+  Max: 282
 
 # Offense count: 5
 Metrics/CyclomaticComplexity:

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ This release will focus on adding any new features covered by open issues
 * allow Ruby 1.9.3 failures to not cause the overall build to fail on Travis
 * switch to latest 2.0.x, 2.1.x, and 2.2.x releases of Ruby
 * enhance 'knife vault show VAULTNAME' (without an item name) to list the names of the items in the vault for parity with 'knife data bag show'
+* add #raw_keys to ChefVault::Item that calls #keys on the underlying data bag item.  We can't make ChefVault::Item work like a true hash without breaking the public API, but this at least makes it easier to get a list of keys
 
 ## v2.7.0
 

--- a/lib/chef-vault/item.rb
+++ b/lib/chef-vault/item.rb
@@ -21,6 +21,13 @@ class ChefVault
     attr_accessor :keys
     attr_accessor :encrypted_data_bag_item
 
+    # returns the raw keys of the underlying Chef::DataBagItem.  chef-vault v2
+    # defined #keys as a public accessor that returns the ChefVault::ItemKeys
+    # object for the vault.  Ideally, #keys would provide Hash-like behaviour
+    # as it does for Chef::DataBagItem, but this would break the API.  We will
+    # revisit this as part of the 3.x rewrite
+    def_delegator :@raw_data, :keys, :raw_keys
+
     def initialize(vault, name)
       super() # Don't pass parameters
       @data_bag = vault

--- a/spec/chef-vault/item_spec.rb
+++ b/spec/chef-vault/item_spec.rb
@@ -117,4 +117,12 @@ RSpec.describe ChefVault::Item do
         .to raise_error(ChefVault::Exceptions::AdminNotFound)
     end
   end
+
+  describe '#raw_keys' do
+    it 'should return the keys of the underlying data bag item' do
+      item = ChefVault::Item.new('foo', 'bar')
+      item['foo'] = 'bar'
+      expect(item.raw_keys).to eq(%w(id foo))
+    end
+  end
 end


### PR DESCRIPTION
Add a #raw_keys method to ChefVault::Item that returns the keys of the underlying raw data bag item

This is the best we can do without breaking the public API (which can't happen until v3)
Closes #142