### PR TITLE
Allow the node name and path to the client key to be specified

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,7 +16,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 282
+  Max: 289
 
 # Offense count: 5
 Metrics/CyclomaticComplexity:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,19 +1,14 @@
 ## Planned (Unreleased)
 ## v2.6.0
 
-This release will focus on adding any new features covered by open issues
 * ChefVault::Item#clients can now accept a Chef::ApiClient object instead of a search string.  Requested by @lamont-granquist to make implementing chef-vault into `knife bootstrap` easier
-
 * allow Ruby 1.9.3 failures to not cause the overall build to fail on Travis
 * switch to latest 2.0.x, 2.1.x, and 2.2.x releases of Ruby
-
 * add --clean-unknown-clients switch to `knife vault refresh`
-* as a side effect, `ChefVault::Item` now has a `#refresh` method which can be used to programatically perform the same operation as `knife vault refresh`
-* ChefVault::Item#clients can now accept a Chef::ApiClient object instead of a search string.  Requested by @lamont-granquist to make implementing chef-vault into `knife bootstrap` easier
-* allow Ruby 1.9.3 failures to not cause the overall build to fail on Travis
-* switch to latest 2.0.x, 2.1.x, and 2.2.x releases of Ruby
+  * as a side effect, `ChefVault::Item` now has a `#refresh` method which can be used to programatically perform the same operation as `knife vault refresh`
 * enhance 'knife vault show VAULTNAME' (without an item name) to list the names of the items in the vault for parity with 'knife data bag show'
 * add #raw_keys to ChefVault::Item that calls #keys on the underlying data bag item.  We can't make ChefVault::Item work like a true hash without breaking the public API, but this at least makes it easier to get a list of keys
+* allow ChefVault::Item.new and ChefVault::Item.load to specify an alternate node name and client key path.  See the README for the use case this serves.
 
 ## v2.7.0
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Chef-Vault
+
 [![Gem Version](https://badge.fury.io/rb/chef-vault.png)](http://badge.fury.io/rb/chef-vault)
 
 [![Build Status](https://travis-ci.org/Nordstrom/chef-vault.png?branch=master)](https://travis-ci.org/Nordstrom/chef-vault)
@@ -7,13 +8,17 @@
 
 ## DESCRIPTION:
 
-Gem that allows you to encrypt a Chef Data Bag Item using the public keys of a list of chef nodes. This allows only those chef nodes to decrypt the encrypted values.
+Gem that allows you to encrypt a Chef Data Bag Item using the public keys of
+a list of chef nodes. This allows only those chef nodes to decrypt the
+encrypted values.
 
-For a more detailed explanation of how chef-vault works, please refer to the file THEORY.md
+For a more detailed explanation of how chef-vault works, please refer to the
+file THEORY.md.
 
 ## INSTALLATION:
 
-Be sure you are running the latest version Chef. Versions earlier than 0.10.0 don't support plugins:
+Be sure you are running the latest version Chef. Versions earlier than
+0.10.0 don't support plugins:
 
     gem install chef
 
@@ -21,7 +26,8 @@ This plugin is distributed as a Ruby Gem. To install it, run:
 
     gem install chef-vault
 
-Depending on your system's configuration, you may need to run this command with root privileges.
+Depending on your system's configuration, you may need to run this command
+with root privileges.
 
 ## KNIFE COMMANDS:
 
@@ -33,13 +39,15 @@ To set 'client' as the default mode, add the following line to the knife.rb file
 
     knife[:vault_mode] = 'client'
 
-To set the default list of admins for creating and updating vaults, add the following line to the knife.rb file.
+To set the default list of admins for creating and updating vaults, add the
+following line to the knife.rb file.
 
     knife[:vault_admins] = [ 'example-alice', 'example-bob', 'example-carol' ]
 
 (These values can be overridden on the command line by using -A)
 
-NOTE: chef-vault 1.0 knife commands are not supported!  Please use chef-vault 2.0 commands.
+NOTE: chef-vault 1.0 knife commands are not supported! Please use chef-vault
+2.0 commands.
 
 ### Vault
 
@@ -140,9 +148,12 @@ NOTE: chef-vault 1.0 knife commands are not supported!  Please use chef-vault 2.
 
 ## USAGE IN RECIPES
 
-To use this gem in a recipe to decrypt data you must first install the gem via a chef_gem resource.  Once the gem is installed require the gem and then you can create a new instance of ChefVault.
+To use this gem in a recipe to decrypt data you must first install the gem
+via a chef_gem resource. Once the gem is installed require the gem and then
+you can create a new instance of ChefVault.
 
-NOTE: chef-vault 1.0 style decryption is supported, however it has been deprecated and chef-vault 2.0 decryption should be used instead
+NOTE: chef-vault 1.0 style decryption is supported, however it has been
+deprecated and chef-vault 2.0 decryption should be used instead
 
 ### Example Code
 
@@ -163,17 +174,65 @@ you move the require of chef-vault and the call to `::load` to
 library or provider code, you can install the gem in the converge phase
 instead.
 
+### Specifying an alternate node name or client key path
+
+Normally, the value of `Chef::Config[:node_name]` is used to find the
+per-node encrypted secret in the keys data bag item, and the value of
+`Chef::Config[:client_key]` is used to locate the private key to decrypt
+this secret.
+
+These can be overridden by passing a hash with the keys `:node_name` or
+`:client_key_path` to `ChefVault::Item.load`:
+
+```ruby
+item = ChefVault::Item.load(
+  'passwords', 'root',
+  node_name: 'service_foo',
+  client_key_path: '/secure/place/service_foo.pem'
+)
+item['password']
+```
+
+The above example assumes that you have transferred
+`/secure/place/service_foo.pem` to your system via a secure channel.
+
+This usage allows you to decrypt a vault using a key shared among several
+nodes, which can be helpful when working in cloud environments or other
+configurations where nodes are created dynamically.
+
+### chef_vault_item helper
+
+The [chef-vault cookbook](https://supermarket.chef.io/cookbooks/chef-vault)
+contains a recipe to install the chef-vault gem and a helper method
+`chef_vault_helper` which makes it easier to test cookbooks that use
+chef-vault using Test Kitchen.
+
 ## USAGE STAND ALONE
 
-`chef-vault` can be used as a stand alone binary to decrypt values stored in Chef.  It requires that Chef is installed on the system and that you have a valid knife.rb.  This is useful if you want to mix `chef-vault` into non-Chef recipe code, for example some other script where you want to protect a password.
+`chef-vault` can be used as a stand alone binary to decrypt values stored in
+Chef. It requires that Chef is installed on the system and that you have a
+valid knife.rb. This is useful if you want to mix `chef-vault` into non-Chef
+recipe code, for example some other script where you want to protect a
+password.
 
-It does still require that the data bag has been encrypted for the user's or client's pem and pushed to the Chef server. It mixes Chef into the gem and uses it to go grab the data bag.
+It does still require that the data bag has been encrypted for the user's or
+client's pem and pushed to the Chef server. It mixes Chef into the gem and
+uses it to go grab the data bag.
 
-Do `chef-vault --help` for all available options
+Use `chef-vault --help` to see all all available options
 
 ### Example usage (password)
 
     chef-vault -v passwords -i root -a password -k /etc/chef/knife.rb
+
+## TESTING
+
+To stub vault items in ChefSpec, use the
+[chef-vault-testfixtures](https://rubygems.org/gems/chef-vault-testfixtures)
+gem.
+
+To fall back to unencrypted JSON files in Test Kitchen, use the
+`chef_vault_item` helper in the aforementioned chef-vault cookbook.
 
 ## Authors
 

--- a/bin/chef-vault
+++ b/bin/chef-vault
@@ -89,9 +89,9 @@ require 'chef-vault'
 ChefVault.load_config(options[:chef])
 item = ChefVault::Item.load(options[:vault], options[:item])
 
-puts "#{options[:vault]}/#{options[:item]}"
+$stdout.puts "#{options[:vault]}/#{options[:item]}"
 
 options[:values].split(",").each do |value|
   value.strip! # remove white space
-  puts("\t#{value}: #{item[value]}")
+  $stdout.puts("\t#{value}: #{item[value]}")
 end

--- a/lib/chef-vault/certificate.rb
+++ b/lib/chef-vault/certificate.rb
@@ -24,7 +24,7 @@ class ChefVault
     end
 
     def decrypt_contents
-      puts "WARNING: This method is deprecated, please switch to item['value'] calls"
+      $stdout.puts "WARNING: This method is deprecated, please switch to item['value'] calls"
       @item["contents"]
     end
   end

--- a/lib/chef-vault/user.rb
+++ b/lib/chef-vault/user.rb
@@ -24,7 +24,7 @@ class ChefVault
     end
 
     def decrypt_password
-      puts "WARNING: This method is deprecated, please switch to item['value'] calls"
+      $stdout.puts "WARNING: This method is deprecated, please switch to item['value'] calls"
       @item["password"]
     end
   end

--- a/lib/chef/knife/decrypt.rb
+++ b/lib/chef/knife/decrypt.rb
@@ -24,7 +24,7 @@ class Chef
       banner "knife decrypt VAULT ITEM [VALUES] (options)"
 
       def run
-        puts "DEPRECATION WARNING: knife decrypt is deprecated. Please use knife vault decrypt instead."
+        $stdout.puts "DEPRECATION WARNING: knife decrypt is deprecated. Please use knife vault decrypt instead."
         super
       end
     end

--- a/lib/chef/knife/encrypt_create.rb
+++ b/lib/chef/knife/encrypt_create.rb
@@ -43,7 +43,7 @@ class Chef
         :description => 'File to be added to vault item as file-content'
 
       def run
-        puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
+        $stdout.puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
         super
       end
     end

--- a/lib/chef/knife/encrypt_delete.rb
+++ b/lib/chef/knife/encrypt_delete.rb
@@ -24,7 +24,7 @@ class Chef
       banner "knife encrypt delete VAULT ITEM (options)"
 
       def run
-        puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
+        $stdout.puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
         super
       end
     end

--- a/lib/chef/knife/encrypt_remove.rb
+++ b/lib/chef/knife/encrypt_remove.rb
@@ -34,7 +34,7 @@ class Chef
         :description => 'Chef users to be added as admins'
 
       def run
-        puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
+        $stdout.puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
         super
       end
     end

--- a/lib/chef/knife/encrypt_rotate_keys.rb
+++ b/lib/chef/knife/encrypt_rotate_keys.rb
@@ -24,7 +24,7 @@ class Chef
       banner "knife encrypt rotate keys VAULT ITEM (options)"
 
       def run
-        puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
+        $stdout.puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
         super
       end
     end

--- a/lib/chef/knife/encrypt_update.rb
+++ b/lib/chef/knife/encrypt_update.rb
@@ -43,7 +43,7 @@ class Chef
       banner "knife encrypt update VAULT ITEM VALUES (options)"
 
       def run
-        puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
+        $stdout.puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
         super
       end
     end

--- a/lib/chef/knife/vault_decrypt.rb
+++ b/lib/chef/knife/vault_decrypt.rb
@@ -23,7 +23,7 @@ class Chef
       banner "knife vault decrypt VAULT ITEM [VALUES] (options)"
 
       def run
-        puts "DEPRECATION WARNING: knife vault decrypt is deprecated. Please use knife vault show instead."
+        $stdout.puts "DEPRECATION WARNING: knife vault decrypt is deprecated. Please use knife vault show instead."
         vault = @name_args[0]
         item = @name_args[1]
         values = @name_args[2]

--- a/lib/chef/knife/vault_rotate_all_keys.rb
+++ b/lib/chef/knife/vault_rotate_all_keys.rb
@@ -52,7 +52,7 @@ class Chef
       end
 
       def rotate_vault_item_keys(vault, item, clean_unknown_clients)
-        puts "Rotating keys for: #{vault} #{item}"
+        $stdout.puts "Rotating keys for: #{vault} #{item}"
         ChefVault::Item.load(vault, item).rotate_keys!(clean_unknown_clients)
       end
     end

--- a/lib/chef/knife/vault_update.rb
+++ b/lib/chef/knife/vault_update.rb
@@ -74,7 +74,7 @@ class Chef
             if clean
               clients = vault_item.clients().clone().sort()
               clients.each do |client|
-                puts "Deleting #{client}"
+                $stdout.puts "Deleting #{client}"
                 vault_item.keys.delete(client, "clients")
               end
             end

--- a/spec/chef-vault/certificate_spec.rb
+++ b/spec/chef-vault/certificate_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe ChefVault::Certificate do
     allow(ChefVault::Item).to receive(:load).with("foo", "bar"){ item }
     allow(item).to receive(:[]).with("id"){ "bar" }
     allow(item).to receive(:[]).with("contents"){ "baz" }
+    @orig_stdout = $stdout
+    $stdout = File.open(File::NULL, 'w')
+  end
+
+  after do
+    $stdout = @orig_stdout
   end
 
   describe '#new' do
@@ -22,8 +28,9 @@ RSpec.describe ChefVault::Certificate do
 
   describe 'decrypt_contents' do
     it 'echoes warning' do
-      expect(STDOUT).to receive(:puts).with("WARNING: This method is deprecated, please switch to item['value'] calls")
-      cert.decrypt_contents
+      expect { cert.decrypt_contents }
+        .to output("WARNING: This method is deprecated, please switch to item['value'] calls\n")
+        .to_stdout
     end
 
     it 'returns items contents' do

--- a/spec/chef-vault/user_spec.rb
+++ b/spec/chef-vault/user_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe ChefVault::User do
     allow(ChefVault::Item).to receive(:load).with("foo", "bar"){ item }
     allow(item).to receive(:[]).with("id"){ "bar" }
     allow(item).to receive(:[]).with("password"){ "baz" }
+    @orig_stdout = $stdout
+    $stdout = File.open(File::NULL, 'w')
+  end
+
+  after do
+    $stdout = @orig_stdout
   end
 
   describe '#new' do
@@ -22,8 +28,9 @@ RSpec.describe ChefVault::User do
 
   describe 'decrypt_password' do
     it 'echoes warning' do
-      expect(STDOUT).to receive(:puts).with("WARNING: This method is deprecated, please switch to item['value'] calls")
-      user.decrypt_password
+      expect { user.decrypt_password }
+        .to output("WARNING: This method is deprecated, please switch to item['value'] calls\n")
+        .to_stdout
     end
 
     it 'returns items password' do


### PR DESCRIPTION
Allow the node name and path to the client key to be specified when calling ChefVault::Item.load.

This supports some use cases that are currently painful in cloud environments.  Refer to issue #150 for more details.
