### PR TITLE
Release 2.6.0

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -5,6 +5,10 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
+AllCops:
+  Exclude:
+    - 'features/step_definitions/*.rb'
+
 # Offense count: 12
 Metrics/AbcSize:
   Max: 43
@@ -16,7 +20,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 289
+  Max: 306
 
 # Offense count: 5
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,7 +16,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 281
+  Max: 282
 
 # Offense count: 5
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,7 +16,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 274
+  Max: 281
 
 # Offense count: 5
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,7 +16,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 247
+  Max: 274
 
 # Offense count: 5
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,7 +16,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 282
+  Max: 289
 
 # Offense count: 5
 Metrics/CyclomaticComplexity:

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@ This release will focus on adding any new features covered by open issues
 * allow Ruby 1.9.3 failures to not cause the overall build to fail on Travis
 * switch to latest 2.0.x, 2.1.x, and 2.2.x releases of Ruby
 
+* add --clean-unknown-clients switch to `knife vault refresh`
+* as a side effect, `ChefVault::Item` now has a `#refresh` method which can be used to programatically perform the same operation as `knife vault refresh`
+* ChefVault::Item#clients can now accept a Chef::ApiClient object instead of a search string.  Requested by @lamont-granquist to make implementing chef-vault into `knife bootstrap` easier
+* allow Ruby 1.9.3 failures to not cause the overall build to fail on Travis
+* switch to latest 2.0.x, 2.1.x, and 2.2.x releases of Ruby
+
 ## v2.7.0
 
 This release will focus on reducing tech debt:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,14 +1,4 @@
 ## Planned (Unreleased)
-## v2.6.0
-
-* ChefVault::Item#clients can now accept a Chef::ApiClient object instead of a search string.  Requested by @lamont-granquist to make implementing chef-vault into `knife bootstrap` easier
-* allow Ruby 1.9.3 failures to not cause the overall build to fail on Travis
-* switch to latest 2.0.x, 2.1.x, and 2.2.x releases of Ruby
-* add --clean-unknown-clients switch to `knife vault refresh`
-  * as a side effect, `ChefVault::Item` now has a `#refresh` method which can be used to programatically perform the same operation as `knife vault refresh`
-* enhance 'knife vault show VAULTNAME' (without an item name) to list the names of the items in the vault for parity with 'knife data bag show'
-* add #raw_keys to ChefVault::Item that calls #keys on the underlying data bag item.  We can't make ChefVault::Item work like a true hash without breaking the public API, but this at least makes it easier to get a list of keys
-* allow ChefVault::Item.new and ChefVault::Item.load to specify an alternate node name and client key path.  See the README for the use case this serves.
 
 ## v2.7.0
 
@@ -34,7 +24,24 @@ chef-vault issues on github for news).
 This release will also remove the chef-vault 1.x commands (encrypt/decrypt)
 
 ## Released
+
+## v2.6.0 / 2015-05-13
+
+* ChefVault::Item#clients can now accept a Chef::ApiClient object instead of a search string.  Requested by @lamont-granquist to make implementing chef-vault into `knife bootstrap` easier
+* allow Ruby 1.9.3 failures to not cause the overall build to fail on Travis
+* switch to latest 2.0.x, 2.1.x, and 2.2.x releases of Ruby
+* add --clean-unknown-clients switch to `knife vault refresh`
+  * as a side effect, `ChefVault::Item` now has a `#refresh` method which can be used to programatically perform the same operation as `knife vault refresh`
+* enhance 'knife vault show VAULTNAME' (without an item name) to list the names of the items in the vault for parity with 'knife data bag show'
+* add #raw_keys to ChefVault::Item that calls #keys on the underlying data bag item.  We can't make ChefVault::Item work like a true hash without breaking the public API, but this at least makes it easier to get a list of keys
+* allow ChefVault::Item.new and ChefVault::Item.load to specify an alternate node name and client key path.  See the README for the use case this serves.
+* added ChefVault::Item.vault? predicate that returns true if the item is a vault and false otherwise
+* added ChefVault::Item.data_bag_item_type method that returns one of :normal, :encrypted or :vault
+* added 'knife vault isvault VAULT ITEM' subcommand that exits 0 if the item is a vault and 1 if it is not
+* added 'knife vault itemtype VAULT ITEM' subcommand that outputs 'normal', 'encrypted' or 'vault'
+
 ## v2.5.0 / 2015-02-09
+
 * when decrypting, if the vault is encrypted for the node but decryption fails, emit a more friendly error message than 'OpenSSL::PKey::RSAError: padding check failed'
 * when attempting to add a client key to a vault item, warn and skip if the node doesn't have a public key (reported by Nik Ormseth)
 * add a new 'knife vault list' command that lists the data bags that are vaults
@@ -43,23 +50,28 @@ This release will also remove the chef-vault 1.x commands (encrypt/decrypt)
 * add rubocop tasks to Rakefile and take a first pass at the low-hanging fruit
 
 ## v2.4.0 / 2014-12-03
+
 * add simplecov test coverage configuration (Doug Ireton)
 * add --clean-unknown-clients switch to knife remove/rotate (Thomas Gschwind and Reto Hermann)
 
 ## v2.3.0 / 2014-10-22
+
 * add --clean switch to knife update (thanks to Matt Brimstone)
 * added aruba CLI testing framework (just for --clean option for now)
 * add Ruby 2.0.x and 2.1.x to Travis platforms
 
 ## v2.2.2 / 2014-06-03
+
 * Add knife vault refresh command
 * Use node_name as a default admin
 * Add DEMO for users
 
 ## v2.2.1 / 2014-02-26
+
 * Add vault_admins to knife.rb for a default set of vault admins
 
 ## v2.2.0 / 2014-01-21
+
 * Validate data bag ID before saving
 * Add search_query to vault metadata
 * Refactor knife commands to be knife vault verb
@@ -71,16 +83,19 @@ This release will also remove the chef-vault 1.x commands (encrypt/decrypt)
 * Fix more README typos
 
 ## v2.1.0 / 2013-12-23
+
 * Update README to correct typos
 * Modify admin loading to fall back to clients endpoint if not found in users endpoint
 * Add --file to "knife encrypt update" & "knife encrypt create" to do file encryption in chef-vault.  It will create a key called "file-content" & "file-name"
 * When VALUES is not supplied print the whole vault item
 
 ## v2.0.2 / 2013-09-10
+
 * Modify written data bag json files in solo mode to be valid for the knife data bag from file command
 * Modify knife encrypt remove to automatically rotate keys
 
 ## v2.0.1 / 2013-09-03
+
 * Removal of knife encrypt certs
 * Removal of knife encrypt passwords
 * Add knife encrypt create
@@ -96,33 +111,44 @@ This release will also remove the chef-vault 1.x commands (encrypt/decrypt)
 * Modify ChefVault::Certificate to use ChefVault::Item to maintain backwards compatability
 
 ## v1.2.5 / 2013-07-22
+
 * Update compat to be class ChefVault not module ChefVault to remove knife errors
 * Allow nodes/clients to be used as Admins
 
 ## v1.2.4 / 2013-07-01
+
 * Move compat include into the lazy-load deps
 * Modify open file commands in knife commands to avoid file locking on windows
 
 ## v1.2.3 / 2013-04-30
+
 * Update to use attr_accessor in chef_vault
 * Add rspec tests
 
 ## v1.2.2 / 2013-04-23
+
 * Update to create data bag folder if it does not already exist
 
 ## v1.2.1 / 2013-04-23
+
 * Clarify Readme
 
 ## v1.0.1 / 2013-04-12
+
 * Compatibility with Chef 10/11 (Shef vs Chef-Shell)
 
 ## v1.0.0 / 2013-04-08
+
 * Rename from Chef-Keepass to Chef-Vault
 
 ## v0.2.1 / 2013-04/05
+
 * Add Certificate class
 
 ## v0.2.0 / 2013-04-05
+
 * Add encrypt cert
 
 ## v0.1.1 / 2013-03-14
+
+* initial release

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ This release will focus on adding any new features covered by open issues
 * ChefVault::Item#clients can now accept a Chef::ApiClient object instead of a search string.  Requested by @lamont-granquist to make implementing chef-vault into `knife bootstrap` easier
 * allow Ruby 1.9.3 failures to not cause the overall build to fail on Travis
 * switch to latest 2.0.x, 2.1.x, and 2.2.x releases of Ruby
+* enhance 'knife vault show VAULTNAME' (without an item name) to list the names of the items in the vault for parity with 'knife data bag show'
 
 ## v2.7.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ This release will focus on adding any new features covered by open issues
 * allow Ruby 1.9.3 failures to not cause the overall build to fail on Travis
 * switch to latest 2.0.x, 2.1.x, and 2.2.x releases of Ruby
 * enhance 'knife vault show VAULTNAME' (without an item name) to list the names of the items in the vault for parity with 'knife data bag show'
+* add #raw_keys to ChefVault::Item that calls #keys on the underlying data bag item.  We can't make ChefVault::Item work like a true hash without breaking the public API, but this at least makes it easier to get a list of keys
 
 ## v2.7.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,19 +1,14 @@
 ## Planned (Unreleased)
 ## v2.6.0
 
-This release will focus on adding any new features covered by open issues
 * ChefVault::Item#clients can now accept a Chef::ApiClient object instead of a search string.  Requested by @lamont-granquist to make implementing chef-vault into `knife bootstrap` easier
-
 * allow Ruby 1.9.3 failures to not cause the overall build to fail on Travis
 * switch to latest 2.0.x, 2.1.x, and 2.2.x releases of Ruby
-
 * add --clean-unknown-clients switch to `knife vault refresh`
-* as a side effect, `ChefVault::Item` now has a `#refresh` method which can be used to programatically perform the same operation as `knife vault refresh`
-* ChefVault::Item#clients can now accept a Chef::ApiClient object instead of a search string.  Requested by @lamont-granquist to make implementing chef-vault into `knife bootstrap` easier
-* allow Ruby 1.9.3 failures to not cause the overall build to fail on Travis
-* switch to latest 2.0.x, 2.1.x, and 2.2.x releases of Ruby
+  * as a side effect, `ChefVault::Item` now has a `#refresh` method which can be used to programatically perform the same operation as `knife vault refresh`
 * enhance 'knife vault show VAULTNAME' (without an item name) to list the names of the items in the vault for parity with 'knife data bag show'
 * add #raw_keys to ChefVault::Item that calls #keys on the underlying data bag item.  We can't make ChefVault::Item work like a true hash without breaking the public API, but this at least makes it easier to get a list of keys
+* allow ChefVault::Item.new and ChefVault::Item.load to specify an alternate node name and client key path.  See the README for the use case this serves.
 
 ## v2.7.0
 

--- a/KNIFE_EXAMPLES.md
+++ b/KNIFE_EXAMPLES.md
@@ -96,13 +96,18 @@ Delete the item root from the vault passwords
     knife vault delete passwords root
 
 ### show
-knife vault show VAULT ITEM [VALUES]
+
+knife vault show VAULT [ITEM] [VALUES]
 
 These are the commands that are used to decrypt a chef-vault encrypted item and show the requested values.
 
-* Vault - This is the name of the vault in which to store the encrypted item.  This is analogous to a chef data bag name
-* Item - The name of the item going in to the vault.  This is analogous to a chef data bag item id
-* Values - This is a comma list of values to decrypt from the vault item.  This is analogous to a list of hash keys.
+* vault - This is the name of the vault in which to store the encrypted item.  This is analogous to a chef data bag name
+* item - The name of the item going in to the vault.  This is analogous to a chef data bag item id
+* values - This is a comma list of values to decrypt from the vault item.  This is analogous to a list of hash keys.
+
+Show the items in a vault
+
+    knife vault show passwords
 
 Show the entire root item in the passwords vault and print in JSON format.
 

--- a/KNIFE_EXAMPLES.md
+++ b/KNIFE_EXAMPLES.md
@@ -160,6 +160,10 @@ This command reads the search_query in the vault item, performs the search, and 
 
     knife vault refresh VAULT ITEM
 
+To remove clients which have been deleted from Chef but not from the vault, add the --clean-unknown-clients switch:
+
+    knife vault refresh passwords root --clean-unknown-clients
+
 ### global options
 <table>
   <tr>

--- a/KNIFE_EXAMPLES.md
+++ b/KNIFE_EXAMPLES.md
@@ -1,13 +1,14 @@
 # knife examples
 
 ## vault
-knife vault *\<command\>* VAULT ITEM VALUES
+
+    knife vault SUBCOMMAND VAULT ITEM VALUES
 
 These are the commands that are used to take data in JSON format and encrypt that data into chef-vault style encrypted data bags in chef.
 
-* Vault - This is the name of the vault in which to store the encrypted item.  This is analogous to a chef data bag name
-* Item - The name of the item going in to the vault.  This is analogous to a chef data bag item id
-* Values - This is the JSON clear text data to be stored in the vault encrypted.  This is analogous to a chef data bag item data
+* vault - This is the name of the vault in which to store the encrypted item.  This is analogous to a chef data bag name
+* item - The name of the item going in to the vault.  This is analogous to a chef data bag item id
+* values - This is the JSON clear text data to be stored in the vault encrypted.  This is analogous to a chef data bag item data
 
 ## vault commands
 
@@ -31,6 +32,7 @@ Create a vault called passwords and put an item called root in it encrypted for 
 Note: A JSON file can be used in place of specifying the values on the command line, see global options below for details
 
 ### update
+
 Update the values in username and password in the vault passwords and item root.  Will overwrite existing values if values already exist!
 
     knife vault update passwords root '{"username": "root", "password": "mypassword"}'
@@ -62,6 +64,7 @@ Add admin1 & admin2 to encrypted admins and role:webserver to encrypted clients 
 Note: A JSON file can be used in place of specifying the values on the command line, see global options below for details
 
 ### remove
+
 Remove the values in username and password from the vault passwords and item root.
 
     knife vault remove passwords root '{"username": "root", "password": "mypassword"}'
@@ -91,6 +94,7 @@ Remove admin1 & admin2 from encrypted admins and role:webserver from encrypted c
     knife vault remove passwords root -S "role:webserver" -A "admin1,admin2"
 
 ### delete
+
 Delete the item root from the vault passwords
 
     knife vault delete passwords root
@@ -126,6 +130,7 @@ Show the contents for the item user_pem in the vault certs.
     knife vault show certs user_pem "contents"
 
 ### edit
+
 knife vault edit VAULT ITEM
 
 These are the commands that are used to edit a chef-vault encrypted item.
@@ -138,11 +143,13 @@ Decrypt the entire root item in the passwords vault and open it in json format i
     knife vault edit passwords root
 
 ### download
+
 Decrypt and download an encrypted file to the specified path.
 
     knife vault download certs user_pem ~/downloaded_user_pem
 
 ### rotate keys
+
 Rotate the shared key for the vault passwords and item root. The shared key is that which is used for the chef encrypted data bag item.
 
     knife vault rotate keys passwords root
@@ -152,6 +159,7 @@ To remove clients which have been deleted from Chef but not from the vault, add 
     knife vault rotate keys passwords root --clean-unknown-clients
 
 ### rotate all keys
+
 Rotate the shared key for all vaults and items. The shared key is that which is used for the chef encrypted data bag item.
 
     knife vault rotate all keys
@@ -161,6 +169,7 @@ To remove clients which have been deleted from Chef but not from the vault, add 
     knife vault rotate keys passwords root --clean-unknown-clients
 
 ### refresh
+
 This command reads the search_query in the vault item, performs the search, and reapplies the results.
 
     knife vault refresh VAULT ITEM
@@ -169,70 +178,27 @@ To remove clients which have been deleted from Chef but not from the vault, add 
 
     knife vault refresh passwords root --clean-unknown-clients
 
+### isvault
+
+This command checks if the given item is a vault or not, and exit with a status of 0 if it is and 1 if it is not.
+
+    knife vault isvault VAULT ITEM
+
+### itemtype
+
+This command outputs the type of the data bag item: normal, encrypted or vault
+
+    knife vault itemtype VAULT ITEM
+
 ### global options
-<table>
-  <tr>
-    <th>Short</th>
-    <th>Long</th>
-    <th>Description</th>
-    <th>Default</th>
-    <th>Valid Values</th>
-    <th>Sub-Commands</th>
-  </tr>
-  <tr>
-    <td>-M MODE</td>
-    <td>--mode MODE</td>
-    <td>Chef mode to run in</td>
-    <td>solo</td>
-    <td>"solo", "client"</td>
-    <td>all</td>
-  </tr>
-  <tr>
-    <td>-S SEARCH</td>
-    <td>--search SEARCH</td>
-    <td>Chef Server SOLR Search Of Nodes</td>
-    <td>nil</td>
-    <td></td>
-    <td>create, remove, update</td>
-  </tr>
-  <tr>
-    <td>-A ADMINS</td>
-    <td>--admins ADMINS</td>
-    <td>Chef clients or users to be vault admins, can be comma list</td>
-    <td>nil</td>
-    <td></td>
-    <td>create, remove, update</td>
-  </tr>
-  <tr>
-    <td>-J FILE</td>
-    <td>--json FILE</td>
-    <td>JSON file to be used for values, will be merged with VALUES if VALUES is passed</td>
-    <td>nil</td>
-    <td></td>
-    <td>create, update</td>
-  </tr>
-  <tr>
-    <td>nil</td>
-    <td>--file FILE</td>
-    <td>File that chef-vault should encrypt.  It adds "file-content" & "file-name" keys to the vault item</td>
-    <td>nil</td>
-    <td></td>
-    <td>create, update</td>
-  </tr>
-  <tr>
-    <td>-p DATA</td>
-    <td>--print DATA</td>
-    <td>Print extra vault data</td>
-    <td>nil</td>
-    <td>"search", "clients", "admins", "all"</td>
-    <td>show</td>
-  </tr>
-  <tr>
-    <td>-F FORMAT</td>
-    <td>--format FORMAT</td>
-    <td>Format for decrypted output</td>
-    <td>summary</td>
-    <td>"summary", "json", "yaml", "pp"</td>
-    <td>show</td>
-  </tr>
-</table>
+
+Short | Long | Description | Default | Valid Values | Sub-Commands
+------|------|-------------|---------|--------------|-------------
+-M MODE | --mode MODE | Chef mode to run in. Can be set in knife.rb | solo | solo, client | all
+-S SEARCH | --search SEARCH | Chef Server SOLR Search Of Nodes | | | create, remove , update
+-A ADMINS | --admins ADMINS | Chef clients or users to be vault admins, can be comma list | | | create, remove, update
+-J FILE | --json FILE | JSON file to be used for values, will be merged with VALUES if VALUES is passed | | | create, update
+| --file FILE | File that chef-vault should encrypt.  It adds "file-content" & "file-name" keys to the vault item | | | create, update
+-p DATA | --print DATA | Print extra vault data | | search, clients, admins, all | show
+-F FORMAT | --format FORMAT | Format for decrypted output | summary | summary, json, yaml, pp | show
+| --clean-unknown-clients | Remove unknown clients during key rotation | | | refresh, remove, rotate

--- a/README.md
+++ b/README.md
@@ -193,6 +193,40 @@ gem.
 To fall back to unencrypted JSON files in Test Kitchen, use the
 `chef_vault_item` helper in the aforementioned chef-vault cookbook.
 
+## THE FUTURE OF chef-vault
+
+It has become clear that supporting alternate keying mechanisms like GPG and
+Amazon KMS is something that chef-vault users want, but the implementation
+of chef-vault v2 makes this difficult, as much of the code is tied to the
+"side-along data bag item" implementation.
+
+chef-vault v3.x.x will be a major rewrite. While the core vault item will
+remain a Chef encrypted data bag item, the way in which you get the secret
+to decrypt that data bag item will be delegated to plugins. At release,
+there will be at least a plugin that emulates the 2.x.x implementation, and
+hopefully one for KMS. Anyone who wants to support an alternate keying
+implementation will be able to write one and distribute it as a gem for
+others to use.
+
+With that in mind, the 2.6.0 release is the last one that will receive new
+features. If you refer to the
+[milestones](https://github.com/Nordstrom/chef-vault/milestones) on Github,
+the plan is for two releases prior to 3.x:
+
+* v2.7.x will focus on reducing tech debt - getting the test coverage up to 100%
+in both RSpec and Aruba, and getting the internal API docs completed.
+* v2.99.x will be a transitional release. This release will add deprecation
+warnings for any API or CLI option that will be changing in v3.x. Any user
+who wants to stay with the 2.x series can use a '~> 2.x' constraint (where x
+is any minor release of chef-vault) and be certain that they won't
+accidentally get the new release.
+
+If you are interested helping with the robustness fixes in v2.7.x, please
+feel free to fork the repo and add more RSpec and Aruba tests. Frequent
+small pull requests are preferred to large omnibus patches, as the
+robustness pass is a multi-person effort and we don't want to create merge
+conflicts unnecessarily.
+
 ## Authors
 
 Author:: Kevin Moser - @moserke<br>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Chef-Vault
+
 [![Gem Version](https://badge.fury.io/rb/chef-vault.png)](http://badge.fury.io/rb/chef-vault)
 
 [![Build Status](https://travis-ci.org/Nordstrom/chef-vault.png?branch=master)](https://travis-ci.org/Nordstrom/chef-vault)
@@ -7,13 +8,17 @@
 
 ## DESCRIPTION:
 
-Gem that allows you to encrypt a Chef Data Bag Item using the public keys of a list of chef nodes. This allows only those chef nodes to decrypt the encrypted values.
+Gem that allows you to encrypt a Chef Data Bag Item using the public keys of
+a list of chef nodes. This allows only those chef nodes to decrypt the
+encrypted values.
 
-For a more detailed explanation of how chef-vault works, please refer to the file THEORY.md
+For a more detailed explanation of how chef-vault works, please refer to the
+file THEORY.md.
 
 ## INSTALLATION:
 
-Be sure you are running the latest version Chef. Versions earlier than 0.10.0 don't support plugins:
+Be sure you are running the latest version Chef. Versions earlier than
+0.10.0 don't support plugins:
 
     gem install chef
 
@@ -21,7 +26,8 @@ This plugin is distributed as a Ruby Gem. To install it, run:
 
     gem install chef-vault
 
-Depending on your system's configuration, you may need to run this command with root privileges.
+Depending on your system's configuration, you may need to run this command
+with root privileges.
 
 ## KNIFE COMMANDS:
 
@@ -33,13 +39,15 @@ To set 'client' as the default mode, add the following line to the knife.rb file
 
     knife[:vault_mode] = 'client'
 
-To set the default list of admins for creating and updating vaults, add the following line to the knife.rb file.
+To set the default list of admins for creating and updating vaults, add the
+following line to the knife.rb file.
 
     knife[:vault_admins] = [ 'example-alice', 'example-bob', 'example-carol' ]
 
 (These values can be overridden on the command line by using -A)
 
-NOTE: chef-vault 1.0 knife commands are not supported!  Please use chef-vault 2.0 commands.
+NOTE: chef-vault 1.0 knife commands are not supported! Please use chef-vault
+2.0 commands.
 
 ### Vault
 
@@ -140,9 +148,12 @@ NOTE: chef-vault 1.0 knife commands are not supported!  Please use chef-vault 2.
 
 ## USAGE IN RECIPES
 
-To use this gem in a recipe to decrypt data you must first install the gem via a chef_gem resource.  Once the gem is installed require the gem and then you can create a new instance of ChefVault.
+To use this gem in a recipe to decrypt data you must first install the gem
+via a chef_gem resource. Once the gem is installed require the gem and then
+you can create a new instance of ChefVault.
 
-NOTE: chef-vault 1.0 style decryption is supported, however it has been deprecated and chef-vault 2.0 decryption should be used instead
+NOTE: chef-vault 1.0 style decryption is supported, however it has been
+deprecated and chef-vault 2.0 decryption should be used instead
 
 ### Example Code
 
@@ -163,17 +174,65 @@ you move the require of chef-vault and the call to `::load` to
 library or provider code, you can install the gem in the converge phase
 instead.
 
+### Specifying an alternate node name or client key path
+
+Normally, the value of `Chef::Config[:node_name]` is used to find the
+per-node encrypted secret in the keys data bag item, and the value of
+`Chef::Config[:client_key]` is used to locate the private key to decrypt
+this secret.
+
+These can be overridden by passing a hash with the keys `:node_name` or
+`:client_key_path` to `ChefVault::Item.load`:
+
+```ruby
+item = ChefVault::Item.load(
+  'passwords', 'root',
+  node_name: 'service_foo',
+  client_key_path: '/secure/place/service_foo.pem'
+)
+item['password']
+```
+
+The above example assumes that you have transferred
+`/secure/place/service_foo.pem` to your system via a secure channel.
+
+This usage allows you to decrypt a vault using a key shared among several
+nodes, which can be helpful when working in cloud environments or other
+configurations where nodes are created dynamically.
+
+### chef_vault_item helper
+
+The [chef-vault cookbook](https://supermarket.chef.io/cookbooks/chef-vault)
+contains a recipe to install the chef-vault gem and a helper method
+`chef_vault_helper` which makes it easier to test cookbooks that use
+chef-vault using Test Kitchen.
+
 ## USAGE STAND ALONE
 
-`chef-vault` can be used as a stand alone binary to decrypt values stored in Chef.  It requires that Chef is installed on the system and that you have a valid knife.rb.  This is useful if you want to mix `chef-vault` into non-Chef recipe code, for example some other script where you want to protect a password.
+`chef-vault` can be used as a stand alone binary to decrypt values stored in
+Chef. It requires that Chef is installed on the system and that you have a
+valid knife.rb. This is useful if you want to mix `chef-vault` into non-Chef
+recipe code, for example some other script where you want to protect a
+password.
 
-It does still require that the data bag has been encrypted for the user's or client's pem and pushed to the Chef server. It mixes Chef into the gem and uses it to go grab the data bag.
+It does still require that the data bag has been encrypted for the user's or
+client's pem and pushed to the Chef server. It mixes Chef into the gem and
+uses it to go grab the data bag.
 
-Do `chef-vault --help` for all available options
+Use `chef-vault --help` to see all all available options
 
 ### Example usage (password)
 
     chef-vault -v passwords -i root -a password -k /etc/chef/knife.rb
+
+## TESTING
+
+To stub vault items in ChefSpec, use the
+[chef-vault-testfixtures](https://rubygems.org/gems/chef-vault-testfixtures)
+gem.
+
+To fall back to unencrypted JSON files in Test Kitchen, use the
+`chef_vault_item` helper in the aforementioned chef-vault cookbook.
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![Build Status](https://travis-ci.org/Nordstrom/chef-vault.png?branch=master)](https://travis-ci.org/Nordstrom/chef-vault)
 
+[![Inline docs](http://inch-ci.org/github/nordstrom/chef-vault.svg?branch=master)](http://inch-ci.org/github/nordstrom/chef-vault)
+
 [![Code Climate](https://codeclimate.com/github/Nordstrom/chef-vault/badges/gpa.svg)](https://codeclimate.com/github/Nordstrom/chef-vault)
 
 ## DESCRIPTION:
@@ -61,90 +63,21 @@ NOTE: chef-vault 1.0 knife commands are not supported! Please use chef-vault
     knife vault rotate all keys
     knife vault show VAULT [ITEM] [VALUES]
     knife vault download VAULT ITEM PATH
+    knife vault isvault VAULT ITEM
+    knife vault itemtype VAULT ITEM
 
-<i>Global Options:</i>
-<table>
-  <tr>
-    <th>Short</th>
-    <th>Long</th>
-    <th>Description</th>
-    <th>Default</th>
-    <th>Valid Values</th>
-    <th>Sub-Commands</th>
-  </tr>
-  <tr>
-    <td>-M MODE</td>
-    <td>--mode MODE</td>
-    <td>Chef mode to run in. Can be set in knife.rb</td>
-    <td>solo</td>
-    <td>"solo", "client"</td>
-    <td>all</td>
-  </tr>
-  <tr>
-    <td>-S SEARCH</td>
-    <td>--search SEARCH</td>
-    <td>Chef Server SOLR Search Of Nodes</td>
-    <td>nil</td>
-    <td></td>
-    <td>create, remove, update</td>
-  </tr>
-  <tr>
-    <td>-A ADMINS</td>
-    <td>--admins ADMINS</td>
-    <td>Chef clients or users to be vault admins, can be comma list</td>
-    <td>nil</td>
-    <td></td>
-    <td>create, remove, update</td>
-  </tr>
-  <tr>
-    <td>-J FILE</td>
-    <td>--json FILE</td>
-    <td>JSON file to be used for values, will be merged with VALUES if VALUES is passed</td>
-    <td>nil</td>
-    <td></td>
-    <td>create, update</td>
-  </tr>
-  <tr>
-    <td>nil</td>
-    <td>--file FILE</td>
-    <td>File that chef-vault should encrypt.  It adds "file-content" & "file-name" keys to the vault item</td>
-    <td>nil</td>
-    <td></td>
-    <td>create, update</td>
-  </tr>
-  <tr>
-    <td>-p DATA</td>
-    <td>--print DATA</td>
-    <td>Print extra vault data</td>
-    <td>nil</td>
-    <td>"search", "clients", "admins", "all"</td>
-    <td>show</td>
-  </tr>
-  <tr>
-    <td>-F FORMAT</td>
-    <td>--format FORMAT</td>
-    <td>Format for decrypted output</td>
-    <td>summary</td>
-    <td>"summary", "json", "yaml", "pp"</td>
-    <td>show</td>
-  </tr>
-  <tr>
-    <td>nil</td>
-    <td>--clean</td>
-    <td>Remove all client keys before re-encrypting with saved or specified search</td>
-    <td>nil</td>
-    <td>nil</td>
-    <td>update</td>
-  </tr>
-  <tr>
-    <td>nil</td>
-    <td>--clean-unknown-clients</td>
-    <td>Remove unknown clients during key rotation</td>
-    <td>nil</td>
-    <td>nil</td>
-    <td>refresh, remove, rotate</td>
-  </tr>
-</table>
+#### Global Options
+
+Short | Long | Description | Default | Valid Values | Sub-Commands
+------|------|-------------|---------|--------------|-------------
+-M MODE | --mode MODE | Chef mode to run in. Can be set in knife.rb | solo | solo, client | all
+-S SEARCH | --search SEARCH | Chef Server SOLR Search Of Nodes | | | create, remove , update
+-A ADMINS | --admins ADMINS | Chef clients or users to be vault admins, can be comma list | | | create, remove, update
+-J FILE | --json FILE | JSON file to be used for values, will be merged with VALUES if VALUES is passed | | | create, update
+| --file FILE | File that chef-vault should encrypt.  It adds "file-content" & "file-name" keys to the vault item | | | create, update
+-p DATA | --print DATA | Print extra vault data | | search, clients, admins, all | show
+-F FORMAT | --format FORMAT | Format for decrypted output | summary | summary, json, yaml, pp | show
+| --clean-unknown-clients | Remove unknown clients during key rotation | | | refresh, remove, rotate
 
 ## USAGE IN RECIPES
 
@@ -157,16 +90,14 @@ deprecated and chef-vault 2.0 decryption should be used instead
 
 ### Example Code
 
-```ruby
-chef_gem 'chef-vault' do
-  compile_time true if respond_to?(:compile_time)
-end
+    chef_gem 'chef-vault' do
+      compile_time true if respond_to?(:compile_time)
+    end
 
-require 'chef-vault'
+    require 'chef-vault'
 
-item = ChefVault::Item.load("passwords", "root")
-item["password"]
-```
+    item = ChefVault::Item.load("passwords", "root")
+    item["password"]
 
 Note that in this case, the gem needs to be installed at compile time
 because the require statement is at the top-level of the recipe.  If
@@ -184,14 +115,12 @@ this secret.
 These can be overridden by passing a hash with the keys `:node_name` or
 `:client_key_path` to `ChefVault::Item.load`:
 
-```ruby
-item = ChefVault::Item.load(
-  'passwords', 'root',
-  node_name: 'service_foo',
-  client_key_path: '/secure/place/service_foo.pem'
-)
-item['password']
-```
+    item = ChefVault::Item.load(
+      'passwords', 'root',
+      node_name: 'service_foo',
+      client_key_path: '/secure/place/service_foo.pem'
+    )
+    item['password']
 
 The above example assumes that you have transferred
 `/secure/place/service_foo.pem` to your system via a secure channel.
@@ -206,6 +135,36 @@ The [chef-vault cookbook](https://supermarket.chef.io/cookbooks/chef-vault)
 contains a recipe to install the chef-vault gem and a helper method
 `chef_vault_helper` which makes it easier to test cookbooks that use
 chef-vault using Test Kitchen.
+
+## DETERMINING IF AN ITEM IS A VAULT
+
+ChefVault provides a helper method to determine if a data bag item is a vault,
+which can be helpful if you produce a recipe for community consumption and want
+to support both normal data bags and vaults:
+
+    if ChefVault::Item.vault?('passwords', 'root')
+      item = ChefVault::Item.load('passwords', 'root')
+    else
+      item = Chef::DataBagItem.load('passwords', 'root')
+    end
+
+This functionality is also available from the command line as `knife vault isvault VAULT ITEM`.
+
+## DETERMINING THE TYPE OF A DATA BAG ITEM
+
+ChefVault provides a helper method to determine the type of a data bag item.
+It returns one of the symbols :normal, :encrypted or :vault
+
+    case ChefVault::Item.data_bag_item_type('passwords', 'root')
+    when :normal
+      ...
+    when :encrypted
+      ...
+    when :vault
+      ...
+    end
+
+This functionality is also available from the command line as `knife vault itemtype VAULT ITEM`.
 
 ## USAGE STAND ALONE
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ NOTE: chef-vault 1.0 knife commands are not supported!  Please use chef-vault 2.
     <td>Remove unknown clients during key rotation</td>
     <td>nil</td>
     <td>nil</td>
-    <td>remove, rotate</td>
+    <td>refresh, remove, rotate</td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -24,16 +24,18 @@ This plugin is distributed as a Ruby Gem. To install it, run:
 Depending on your system's configuration, you may need to run this command with root privileges.
 
 ## KNIFE COMMANDS:
+
 See KNIFE_EXAMPLES.md for examples of commands
 
 ### knife.rb
+
 To set 'client' as the default mode, add the following line to the knife.rb file.
 
-```knife[:vault_mode] = 'client'```
+    knife[:vault_mode] = 'client'
 
 To set the default list of admins for creating and updating vaults, add the following line to the knife.rb file.
 
-```knife[:vault_admins] = [ 'example-alice', 'example-bob', 'example-carol' ]```
+    knife[:vault_admins] = [ 'example-alice', 'example-bob', 'example-carol' ]
 
 (These values can be overridden on the command line by using -A)
 
@@ -49,7 +51,7 @@ NOTE: chef-vault 1.0 knife commands are not supported!  Please use chef-vault 2.
     knife vault delete VAULT ITEM
     knife vault rotate keys VAULT ITEM
     knife vault rotate all keys
-    knife vault show VAULT ITEM [VALUES]
+    knife vault show VAULT [ITEM] [VALUES]
     knife vault download VAULT ITEM PATH
 
 <i>Global Options:</i>

--- a/bin/chef-vault
+++ b/bin/chef-vault
@@ -89,9 +89,9 @@ require 'chef-vault'
 ChefVault.load_config(options[:chef])
 item = ChefVault::Item.load(options[:vault], options[:item])
 
-puts "#{options[:vault]}/#{options[:item]}"
+$stdout.puts "#{options[:vault]}/#{options[:item]}"
 
 options[:values].split(",").each do |value|
   value.strip! # remove white space
-  puts("\t#{value}: #{item[value]}")
+  $stdout.puts("\t#{value}: #{item[value]}")
 end

--- a/chef-vault.gemspec
+++ b/chef-vault.gemspec
@@ -35,12 +35,12 @@ Gem::Specification.new do |s|
   s.executables      = %w( chef-vault )
 
   s.add_development_dependency 'rake', '~> 10.4'
-  s.add_development_dependency 'rspec', '~> 3.1'
+  s.add_development_dependency 'rspec', '~> 3.2'
   s.add_development_dependency 'rspec-its', '~> 1.1'
   s.add_development_dependency 'aruba', '~> 0.6'
   s.add_development_dependency 'simplecov', '~> 0.9'
   s.add_development_dependency 'simplecov-console', '~> 0.2'
-  s.add_development_dependency 'rubocop', '~> 0.29'
+  s.add_development_dependency 'rubocop', '~> 0.30'
   # Chef 12 and higher pull in Ohai 8, which needs Ruby v2
   # so only in the case of a CI build on ruby v1, we constrain
   # chef to 11 or lower so that we can maintain CI test coverage

--- a/features/clean_on_refresh.feature
+++ b/features/clean_on_refresh.feature
@@ -1,0 +1,28 @@
+Feature: clean unknown clients on vault refresh
+
+  When refreshing a vault, new clients may be added if they match
+  the search query or client list, but old clients that no longer
+  exist will never be removed.  The --clean-unknown-clients switch
+  will cause cause any unknown clients to be removed from the vault
+  item's access list as well
+
+  Scenario: Refresh without clean option
+    Given a local mode chef repo with nodes 'one,two,three'
+    And I create a vault item 'test/item' containing the JSON '{"foo": "bar"}' encrypted for 'one,two,three'
+    Then the vault item 'test/item' should be encrypted for 'one,two,three'
+    And I delete client 'one' from the Chef server
+    And I refresh the vault item 'test/item'
+    And the vault item 'test/item' should be encrypted for 'one,two,three'
+    And 'one,two,three' should be a client for the vault item 'test/item'
+
+  Scenario: Refresh with clean option
+    Given a local mode chef repo with nodes 'one,two,three'
+    And I create a vault item 'test/item' containing the JSON '{"foo": "bar"}' encrypted for 'one,two,three'
+    Then the vault item 'test/item' should be encrypted for 'one,two,three'
+    And I delete client 'one' from the Chef server
+    And I refresh the vault item 'test/item' with the 'clean-unknown-clients' option
+    Then the output should contain "Removing unknown client 'one'"
+    And the vault item 'test/item' should be encrypted for 'two,three'
+    And the vault item 'test/item' should not be encrypted for 'one'
+    And 'two,three' should be a client for the vault item 'test/item'
+    And 'one' should not be a client for the vault item 'test/item'

--- a/features/isvault.feature
+++ b/features/isvault.feature
@@ -1,0 +1,24 @@
+Feature: determine if a data bag item is a vault
+
+  If a data bag item is a vault, 'knife vault isvault VAULTNAME ITEMNAME'
+  should exit 0.  Otherwise it should exit 1.
+
+  Scenario: detect vault item
+    Given a local mode chef repo with nodes 'one,two,three'
+    And I create a vault item 'test/item' containing the JSON '{"foo": "bar"}' encrypted for 'one,two,three'
+    And I check if the data bag item 'test/item' is a vault
+    Then the exit status should be 0
+
+  Scenario: detect non-vault item (encrypted data bag)
+    Given a local mode chef repo with nodes 'one,two,three'
+    And I create an empty data bag 'test'
+    And I create an encrypted data bag item 'test/item' containing the JSON '{"id": "item", "foo": "bar"}' with the secret 'sekrit'
+    And I check if the data bag item 'test/item' is a vault
+    Then the exit status should not be 0
+
+  Scenario: detect non-vault item (normal data bag)
+    Given a local mode chef repo with nodes 'one,two,three'
+    And I create an empty data bag 'test'
+    And I create a data bag item 'test/item' containing the JSON '{"id": "item", "foo": "bar"}'
+    And I check if the data bag item 'test/item' is a vault
+    Then the exit status should not be 0

--- a/features/itemtype.feature
+++ b/features/itemtype.feature
@@ -1,0 +1,25 @@
+Feature: determine the type of a data bag item
+
+  'knife vault itemtype VAULTNAME ITEMNAME' should output one of
+  'normal', 'encrypted', or 'vault' depending on what type of item
+  it detects
+
+  Scenario: detect vault item
+    Given a local mode chef repo with nodes 'one,two,three'
+    And I create a vault item 'test/item' containing the JSON '{"foo": "bar"}' encrypted for 'one,two,three'
+    And I check the type of the data bag item 'test/item'
+    Then the output should match /^vault$/
+
+  Scenario: detect non-vault item (encrypted data bag)
+    Given a local mode chef repo with nodes 'one,two,three'
+    And I create an empty data bag 'test'
+    And I create an encrypted data bag item 'test/item' containing the JSON '{"id": "item", "foo": "bar"}' with the secret 'sekrit'
+    And I check the type of the data bag item 'test/item'
+    Then the output should match /^encrypted$/
+
+  Scenario: detect non-vault item (normal data bag)
+    Given a local mode chef repo with nodes 'one,two,three'
+    And I create an empty data bag 'test'
+    And I create a data bag item 'test/item' containing the JSON '{"id": "item", "foo": "bar"}'
+    And I check the type of the data bag item 'test/item'
+    Then the output should match /^normal$/

--- a/features/step_definitions/chef-databag.rb
+++ b/features/step_definitions/chef-databag.rb
@@ -3,3 +3,7 @@ When /^I create a data bag '(.+)' containing the JSON '(.+)'$/ do |bag, json|
   run_simple "knife data bag create #{bag} -z -c knife.rb -d"
   run_simple "knife data bag from_file #{bag} -z -c knife.rb item.json"
 end
+
+Given(/^I create an empty data bag '(.+)'$/) do |databag|
+  run_simple "knife data bag create #{databag} -z -c knife.rb", false
+end

--- a/features/step_definitions/chef-vault.rb
+++ b/features/step_definitions/chef-vault.rb
@@ -102,3 +102,7 @@ end
 Given(/^I add '(.+)' as an admin for the vault item '(.+)\/(.+)'$/) do |newadmin, vault, item|
   run_simple "knife vault update #{vault} #{item} -c knife.rb -z -A #{newadmin}"
 end
+
+Given(/^I show the keys of the vault '(.+)'$/) do |vault|
+  run_simple "knife vault show #{vault} -c knife.rb -z"
+end

--- a/features/step_definitions/chef-vault.rb
+++ b/features/step_definitions/chef-vault.rb
@@ -106,3 +106,11 @@ end
 Given(/^I show the keys of the vault '(.+)'$/) do |vault|
   run_simple "knife vault show #{vault} -c knife.rb -z"
 end
+
+Given(/^I check if the data bag item '(.+)\/(.+)' is a vault$/) do |vault, item|
+  run_simple "knife vault isvault #{vault} #{item} -c knife.rb -z", false
+end
+
+Given(/^I check the type of the data bag item '(.+)\/(.+)'$/) do |vault, item|
+  run_simple "knife vault itemtype #{vault} #{item} -c knife.rb -z"
+end

--- a/features/step_definitions/chef-vault.rb
+++ b/features/step_definitions/chef-vault.rb
@@ -28,6 +28,15 @@ Given(/^I rotate all keys with the '(.+)' options?$/) do |optionlist|
   run_simple "knife vault rotate all keys -z -c knife.rb #{options}"
 end
 
+Given(/^I refresh the vault item '(.+)\/(.+)'$/) do |vault, item|
+  run_simple "knife vault refresh #{vault} #{item} -c knife.rb -z"
+end
+
+Given(/^I refresh the vault item '(.+)\/(.+)' with the '(.+)' options?$/) do |vault, item, optionlist|
+  options = optionlist.split(/,/).map{|o| "--#{o}"}.join(' ')
+  run_simple "knife vault refresh #{vault} #{item} -c knife.rb -z #{options}"
+end
+
 Given(/^I try to decrypt the vault item '(.+)\/(.+)' as '(.+)'$/) do |vault, item, node|
   run_simple "knife vault show #{vault} #{item} -z -c knife.rb -u #{node} -k #{node}.pem", false
 end

--- a/features/step_definitions/chef_databagitem.rb
+++ b/features/step_definitions/chef_databagitem.rb
@@ -1,0 +1,9 @@
+Given(/^I create a data bag item '(.+)\/(.+)' containing the JSON '(.+)'$/) do |databag, _, json|
+  write_file 'item.json', json
+  run_simple "knife data bag from file #{databag} item.json -z -c knife.rb", false
+end
+
+Given(/^I create an encrypted data bag item '(.+)\/(.+)' containing the JSON '(.+)' with the secret '(.+)'$/) do |databag, _, json, secret|
+  write_file 'item.json', json
+  run_simple "knife data bag from file #{databag} item.json -s #{secret} -z -c knife.rb", false
+end

--- a/features/vault_show_vaultname.feature
+++ b/features/vault_show_vaultname.feature
@@ -1,0 +1,22 @@
+Feature: knife vault show [VAULTNAME]
+
+  'knife vault show [VAULTNAME]' displays the keys of a vault
+  (i.e. the items that are not suffixed with _keys)
+
+  Scenario: show keys of a vault
+    Given a local mode chef repo with nodes 'one,two,three'
+    And I create a vault item 'test/item' containing the JSON '{"foo": "bar"}' encrypted for 'one,two,three'
+    And I create a vault item 'test/item2' containing the JSON '{"foo": "bar"}' encrypted for 'one,two,three'
+    Then the vault item 'test/item' should be encrypted for 'one,two,three'
+    And 'one,two,three' should be a client for the vault item 'test/item'
+    And I show the keys of the vault 'test'
+    Then the output should match /(?m:^item$)/
+    And the output should match /(?m:^item2$)/
+    And the output should not match /(?m:^item_keys$)/
+    And the output should not match /(?m:^item2_keys$)/
+
+  Scenario: show keys of a data bag that is not a vault
+    Given a local mode chef repo with nodes 'one,two,three'
+    And I create a data bag 'notavault' containing the JSON '{"id": "item", "foo": "bar"}'
+    And I show the keys of the vault 'notavault'
+    Then the output should match /data bag notavault is not a chef-vault/

--- a/features/vault_update.feature
+++ b/features/vault_update.feature
@@ -1,4 +1,4 @@
-Feature: knife vault create
+Feature: knife vault update
 
   'knife vault update' is used to add clients, or administrators
   and to re-run the search query

--- a/features/verify_id_matches.feature
+++ b/features/verify_id_matches.feature
@@ -8,4 +8,4 @@ Feature: knife vault create with mismatched ID
   Scenario: create vault from JSON file with mismatched ID
     Given a local mode chef repo with nodes 'one,two,three'
     And I create a vault item 'test/item' containing the JSON '{"id": "eyetem"}' encrypted for 'one,two,three'
-    Then the output should match /id mismatch - vault has id 'eyetem' but keys has id 'item'/
+    Then the output should match /id mismatch - input JSON has id 'eyetem' but vault item has id 'item'/

--- a/features/verify_id_matches.feature
+++ b/features/verify_id_matches.feature
@@ -1,0 +1,11 @@
+Feature: knife vault create with mismatched ID
+
+  'knife vault create' creates a vault.  A JSON file can be passed
+  on the command line.  If the vault ID specified on the command line
+  does not match the value of the 'id' key in the JSON file, knife
+  should throw an error
+
+  Scenario: create vault from JSON file with mismatched ID
+    Given a local mode chef repo with nodes 'one,two,three'
+    And I create a vault item 'test/item' containing the JSON '{"id": "eyetem"}' encrypted for 'one,two,three'
+    Then the output should match /id mismatch - vault has id 'eyetem' but keys has id 'item'/

--- a/lib/chef-vault/certificate.rb
+++ b/lib/chef-vault/certificate.rb
@@ -24,7 +24,7 @@ class ChefVault
     end
 
     def decrypt_contents
-      puts "WARNING: This method is deprecated, please switch to item['value'] calls"
+      $stdout.puts "WARNING: This method is deprecated, please switch to item['value'] calls"
       @item["contents"]
     end
   end

--- a/lib/chef-vault/exceptions.rb
+++ b/lib/chef-vault/exceptions.rb
@@ -45,5 +45,8 @@ class ChefVault
 
     class SearchNotFound < Exceptions
     end
+
+    class IdMismatch < Exceptions
+    end
   end
 end

--- a/lib/chef-vault/item.rb
+++ b/lib/chef-vault/item.rb
@@ -201,7 +201,7 @@ class ChefVault
       keys_id = keys['id'].match(/^(.+)_keys/)[1]
       if keys_id != item_id
         raise ChefVault::Exceptions::IdMismatch,
-          "id mismatch - vault has id '#{item_id}' but keys has id '#{keys_id}'"
+          "id mismatch - input JSON has id '#{item_id}' but vault item has id '#{keys_id}'"
       end
 
       # save the keys first, raising an error if no keys were defined

--- a/lib/chef-vault/item.rb
+++ b/lib/chef-vault/item.rb
@@ -241,6 +241,31 @@ class ChefVault
       item
     end
 
+    # refreshes a vault by re-processing the search query and
+    # adding a secret for any nodes found (including new ones)
+    # @param clean_unknown_clients [Boolean] remove clients that can
+    #   no longer be found
+    # @return [void]
+    def refresh(clean_unknown_clients = false)
+      unless search
+        raise ChefVault::Exceptions::SearchNotFound,
+              "#{vault}/#{item} does not have a stored search_query, "\
+              'probably because it was created with an older version '\
+              "of chef-vault. Use 'knife vault update' to update the "\
+              'databag with the search query.'
+      end
+
+      # a bit of a misnomer; this doesn't remove unknown
+      # admins, just clients which are nodes
+      remove_unknown_nodes if clean_unknown_clients
+
+      # re-process the search query to add new clients
+      clients(search)
+
+      # save the updated vault
+      save
+    end
+
     private
 
     def encrypt!
@@ -292,7 +317,7 @@ class ChefVault
     end
 
     # removes unknown nodes by performing a node search
-    # for each of the existing nodclientses.  If the search
+    # for each of the existing clients.  If the search
     # returns nothing or the client cannot be loaded, then
     # we remove that client from the vault
     # @return [void]

--- a/lib/chef-vault/item.rb
+++ b/lib/chef-vault/item.rb
@@ -160,6 +160,16 @@ class ChefVault
       # validate the format of the id before attempting to save
       validate_id!(item_id)
 
+      # ensure that the ID of the vault hasn't changed since the keys
+      # data bag item was created
+      keys_id = keys['id'].match(/^(.+)_keys/)[1]
+      puts "item_id is #{item_id}"
+      puts "keys_id is #{keys_id}"
+      if keys_id != item_id
+        raise ChefVault::Exceptions::IdMismatch,
+          "id mismatch - vault has id '#{item_id}' but keys has id '#{keys_id}'"
+      end
+
       # save the keys first, raising an error if no keys were defined
       if keys.admins.empty? && keys.clients.empty?
         raise ChefVault::Exceptions::NoKeysDefined,

--- a/lib/chef-vault/item.rb
+++ b/lib/chef-vault/item.rb
@@ -21,6 +21,13 @@ class ChefVault
     attr_accessor :keys
     attr_accessor :encrypted_data_bag_item
 
+    # returns the raw keys of the underlying Chef::DataBagItem.  chef-vault v2
+    # defined #keys as a public accessor that returns the ChefVault::ItemKeys
+    # object for the vault.  Ideally, #keys would provide Hash-like behaviour
+    # as it does for Chef::DataBagItem, but this would break the API.  We will
+    # revisit this as part of the 3.x rewrite
+    def_delegator :@raw_data, :keys, :raw_keys
+
     def initialize(vault, name)
       super() # Don't pass parameters
       @data_bag = vault

--- a/lib/chef-vault/user.rb
+++ b/lib/chef-vault/user.rb
@@ -24,7 +24,7 @@ class ChefVault
     end
 
     def decrypt_password
-      puts "WARNING: This method is deprecated, please switch to item['value'] calls"
+      $stdout.puts "WARNING: This method is deprecated, please switch to item['value'] calls"
       @item["password"]
     end
   end

--- a/lib/chef-vault/version.rb
+++ b/lib/chef-vault/version.rb
@@ -14,6 +14,6 @@
 # limitations under the License.
 
 class ChefVault
-  VERSION = "2.5.0"
+  VERSION = '2.6.0'
   MAJOR, MINOR, TINY = VERSION.split('.')
 end

--- a/lib/chef/knife/decrypt.rb
+++ b/lib/chef/knife/decrypt.rb
@@ -24,7 +24,7 @@ class Chef
       banner "knife decrypt VAULT ITEM [VALUES] (options)"
 
       def run
-        puts "DEPRECATION WARNING: knife decrypt is deprecated. Please use knife vault decrypt instead."
+        $stdout.puts "DEPRECATION WARNING: knife decrypt is deprecated. Please use knife vault decrypt instead."
         super
       end
     end

--- a/lib/chef/knife/encrypt_create.rb
+++ b/lib/chef/knife/encrypt_create.rb
@@ -43,7 +43,7 @@ class Chef
         :description => 'File to be added to vault item as file-content'
 
       def run
-        puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
+        $stdout.puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
         super
       end
     end

--- a/lib/chef/knife/encrypt_delete.rb
+++ b/lib/chef/knife/encrypt_delete.rb
@@ -24,7 +24,7 @@ class Chef
       banner "knife encrypt delete VAULT ITEM (options)"
 
       def run
-        puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
+        $stdout.puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
         super
       end
     end

--- a/lib/chef/knife/encrypt_remove.rb
+++ b/lib/chef/knife/encrypt_remove.rb
@@ -34,7 +34,7 @@ class Chef
         :description => 'Chef users to be added as admins'
 
       def run
-        puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
+        $stdout.puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
         super
       end
     end

--- a/lib/chef/knife/encrypt_rotate_keys.rb
+++ b/lib/chef/knife/encrypt_rotate_keys.rb
@@ -24,7 +24,7 @@ class Chef
       banner "knife encrypt rotate keys VAULT ITEM (options)"
 
       def run
-        puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
+        $stdout.puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
         super
       end
     end

--- a/lib/chef/knife/encrypt_update.rb
+++ b/lib/chef/knife/encrypt_update.rb
@@ -43,7 +43,7 @@ class Chef
       banner "knife encrypt update VAULT ITEM VALUES (options)"
 
       def run
-        puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
+        $stdout.puts "DEPRECATION WARNING: knife encrypt is deprecated. Please use knife vault instead."
         super
       end
     end

--- a/lib/chef/knife/vault_base.rb
+++ b/lib/chef/knife/vault_base.rb
@@ -41,6 +41,28 @@ class Chef
         super
         exit 1
       end
+
+      private
+
+      def bag_is_vault?(bagname)
+        bag = Chef::DataBag.load(bagname)
+        # vaults have at even number of keys >= 2
+        return false unless bag.keys.size >= 2 && 0 == bag.keys.size % 2
+        # partition into those that end in _keys
+        keylike, notkeylike = split_vault_keys(bag)
+        # there must be an equal number of keyline and not-keylike items
+        return false unless keylike.size == notkeylike.size
+        # strip the _keys suffix and check if the sets match
+        keylike.map! { |k| k.gsub(/_keys$/, '') }
+        return false unless keylike.sort == notkeylike.sort
+        # it's (probably) a vault
+        true
+      end
+
+      def split_vault_keys(bag)
+        # partition into those that end in _keys
+        bag.keys.partition { |k| k =~ /_keys$/ }
+      end
     end
   end
 end

--- a/lib/chef/knife/vault_create.rb
+++ b/lib/chef/knife/vault_create.rb
@@ -63,7 +63,6 @@ class Chef
           rescue ChefVault::Exceptions::KeysNotFound,
                  ChefVault::Exceptions::ItemNotFound
             vault_item = ChefVault::Item.new(vault, item)
-
             if values || json_file || file
               merge_values(values, json_file).each do |key, value|
                 vault_item[key] = value

--- a/lib/chef/knife/vault_decrypt.rb
+++ b/lib/chef/knife/vault_decrypt.rb
@@ -23,7 +23,7 @@ class Chef
       banner "knife vault decrypt VAULT ITEM [VALUES] (options)"
 
       def run
-        puts "DEPRECATION WARNING: knife vault decrypt is deprecated. Please use knife vault show instead."
+        $stdout.puts "DEPRECATION WARNING: knife vault decrypt is deprecated. Please use knife vault show instead."
         vault = @name_args[0]
         item = @name_args[1]
         values = @name_args[2]

--- a/lib/chef/knife/vault_isvault.rb
+++ b/lib/chef/knife/vault_isvault.rb
@@ -1,4 +1,4 @@
-# Description: Chef-Vault VaultList class
+# Description: Chef-Vault VaultIsvault class
 # Copyright 2013, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,10 +17,10 @@ require 'chef/knife/vault_base'
 
 class Chef
   class Knife
-    class VaultList < Knife
+    class VaultIsvault < Knife
       include Chef::Knife::VaultBase
 
-      banner "knife vault list (options)"
+      banner "knife vault isvault VAULT ITEM (options)"
 
       option :mode,
         :short => '-M MODE',
@@ -28,14 +28,15 @@ class Chef
         :description => 'Chef mode to run in default - solo'
 
       def run
-        set_mode(config[:vault_mode])
-        vaultbags = []
-        # iterate over all the data bags
-        bags = Chef::DataBag.list
-        bags.each_key do |bagname|
-          vaultbags.push(bagname) if bag_is_vault?(bagname)
+        vault = @name_args[0]
+        item = @name_args[1]
+
+        if vault && item
+          set_mode(config[:vault_mode])
+          exit ChefVault::Item.vault?(vault, item) ? 0 : 1
+        else
+          show_usage
         end
-        output vaultbags.join("\n")
       end
     end
   end

--- a/lib/chef/knife/vault_itemtype.rb
+++ b/lib/chef/knife/vault_itemtype.rb
@@ -1,4 +1,4 @@
-# Description: Chef-Vault VaultList class
+# Description: Chef-Vault VaultItemtype class
 # Copyright 2013, Nordstrom, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,10 +17,10 @@ require 'chef/knife/vault_base'
 
 class Chef
   class Knife
-    class VaultList < Knife
+    class VaultItemtype < Knife
       include Chef::Knife::VaultBase
 
-      banner "knife vault list (options)"
+      banner "knife vault itemtype VAULT ITEM (options)"
 
       option :mode,
         :short => '-M MODE',
@@ -28,14 +28,15 @@ class Chef
         :description => 'Chef mode to run in default - solo'
 
       def run
-        set_mode(config[:vault_mode])
-        vaultbags = []
-        # iterate over all the data bags
-        bags = Chef::DataBag.list
-        bags.each_key do |bagname|
-          vaultbags.push(bagname) if bag_is_vault?(bagname)
+        vault = @name_args[0]
+        item = @name_args[1]
+
+        if vault && item
+          set_mode(config[:vault_mode])
+          output ChefVault::Item.data_bag_item_type(vault, item)
+        else
+          show_usage
         end
-        output vaultbags.join("\n")
       end
     end
   end

--- a/lib/chef/knife/vault_list.rb
+++ b/lib/chef/knife/vault_list.rb
@@ -31,23 +31,6 @@ class Chef
         end
         output vaultbags.join("\n")
       end
-
-      private
-
-      def bag_is_vault?(bagname)
-        bag = Chef::DataBag.load(bagname)
-        # vaults have at even number of keys >= 2
-        return false unless bag.keys.size >= 2 && 0 == bag.keys.size % 2
-        # partition into those that end in _keys
-        keylike, notkeylike = bag.keys.partition { |k| k =~ /_keys$/ }
-        # there must be an equal number of keyline and not-keylike items
-        return false unless keylike.size == notkeylike.size
-        # strip the _keys suffix and check if the sets match
-        keylike.map! { |k| k.gsub(/_keys$/, '') }
-        return false unless keylike.sort == notkeylike.sort
-        # it's (probably) a vault
-        true
-      end
     end
   end
 end

--- a/lib/chef/knife/vault_refresh.rb
+++ b/lib/chef/knife/vault_refresh.rb
@@ -22,27 +22,21 @@ class Chef
 
       banner "knife vault refresh VAULT ITEM"
 
+      option :clean_unknown_clients,
+        :long => '--clean-unknown-clients',
+        :description => 'Remove unknown clients during refresh'
+
       def run
         vault = @name_args[0]
         item = @name_args[1]
+        clean = config[:clean_unknown_clients]
 
         set_mode(config[:vault_mode])
 
         if vault && item
           begin
             vault_item = ChefVault::Item.load(vault, item)
-            search = vault_item.search
-
-            unless search
-              raise ChefVault::Exceptions::SearchNotFound,
-                    "#{vault}/#{item} does not have a stored search_query, "\
-                    "probably because it was created with an older version "\
-                    "of chef-vault. Use 'knife vault update' to update the "\
-                    "databag with the search query."
-            end
-
-            vault_item.clients(search)
-            vault_item.save
+            vault_item.refresh(clean)
           rescue ChefVault::Exceptions::KeysNotFound,
                  ChefVault::Exceptions::ItemNotFound
 

--- a/lib/chef/knife/vault_rotate_all_keys.rb
+++ b/lib/chef/knife/vault_rotate_all_keys.rb
@@ -52,7 +52,7 @@ class Chef
       end
 
       def rotate_vault_item_keys(vault, item, clean_unknown_clients)
-        puts "Rotating keys for: #{vault} #{item}"
+        $stdout.puts "Rotating keys for: #{vault} #{item}"
         ChefVault::Item.load(vault, item).rotate_keys!(clean_unknown_clients)
       end
     end

--- a/lib/chef/knife/vault_show.rb
+++ b/lib/chef/knife/vault_show.rb
@@ -20,7 +20,7 @@ class Chef
     class VaultShow < Knife
       include Chef::Knife::VaultBase
 
-      banner "knife vault show VAULT ITEM [VALUES] (options)"
+      banner "knife vault show VAULT [ITEM] [VALUES] (options)"
 
       option :mode,
         :short => '-M MODE',
@@ -40,6 +40,9 @@ class Chef
         if vault && item
           set_mode(config[:vault_mode])
           print_values(vault, item, values)
+        elsif vault
+          set_mode(config[:vault_mode])
+          print_keys(vault)
         else
           show_usage
         end
@@ -82,6 +85,17 @@ class Chef
           output_data = all_data.merge(extra_data)
         end
         output(output_data)
+      end
+
+      def print_keys(vault)
+        if bag_is_vault?(vault)
+          bag = Chef::DataBag.load(vault)
+          split_vault_keys(bag)[1].each do |item|
+            output item
+          end
+        else
+          output "data bag #{vault} is not a chef-vault"
+        end
       end
     end
   end

--- a/lib/chef/knife/vault_update.rb
+++ b/lib/chef/knife/vault_update.rb
@@ -74,7 +74,7 @@ class Chef
             if clean
               clients = vault_item.clients().clone().sort()
               clients.each do |client|
-                puts "Deleting #{client}"
+                $stdout.puts "Deleting #{client}"
                 vault_item.keys.delete(client, "clients")
               end
             end

--- a/spec/chef-vault/certificate_spec.rb
+++ b/spec/chef-vault/certificate_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe ChefVault::Certificate do
     allow(ChefVault::Item).to receive(:load).with("foo", "bar"){ item }
     allow(item).to receive(:[]).with("id"){ "bar" }
     allow(item).to receive(:[]).with("contents"){ "baz" }
+    @orig_stdout = $stdout
+    $stdout = File.open(File::NULL, 'w')
+  end
+
+  after do
+    $stdout = @orig_stdout
   end
 
   describe '#new' do
@@ -22,8 +28,9 @@ RSpec.describe ChefVault::Certificate do
 
   describe 'decrypt_contents' do
     it 'echoes warning' do
-      expect(STDOUT).to receive(:puts).with("WARNING: This method is deprecated, please switch to item['value'] calls")
-      cert.decrypt_contents
+      expect { cert.decrypt_contents }
+        .to output("WARNING: This method is deprecated, please switch to item['value'] calls\n")
+        .to_stdout
     end
 
     it 'returns items contents' do

--- a/spec/chef-vault/item_spec.rb
+++ b/spec/chef-vault/item_spec.rb
@@ -117,4 +117,12 @@ RSpec.describe ChefVault::Item do
         .to raise_error(ChefVault::Exceptions::AdminNotFound)
     end
   end
+
+  describe '#raw_keys' do
+    it 'should return the keys of the underlying data bag item' do
+      item = ChefVault::Item.new('foo', 'bar')
+      item['foo'] = 'bar'
+      expect(item.raw_keys).to eq(%w(id foo))
+    end
+  end
 end

--- a/spec/chef-vault/item_spec.rb
+++ b/spec/chef-vault/item_spec.rb
@@ -70,8 +70,14 @@ RSpec.describe ChefVault::Item do
   describe '#save' do
     context 'when item["id"] is bar.bar' do
       let(:item) { ChefVault::Item.new("foo", "bar.bar") }
-
       specify { expect { item.save }.to raise_error }
+    end
+
+    it 'should validate that the id of the vault matches the id of the keys data bag' do
+      item = ChefVault::Item.new('foo', 'bar')
+      item['id'] = 'baz'
+      item.keys['clients'] = %w(admin)
+      expect { item.save }.to raise_error(ChefVault::Exceptions::IdMismatch)
     end
   end
 

--- a/spec/chef-vault/user_spec.rb
+++ b/spec/chef-vault/user_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe ChefVault::User do
     allow(ChefVault::Item).to receive(:load).with("foo", "bar"){ item }
     allow(item).to receive(:[]).with("id"){ "bar" }
     allow(item).to receive(:[]).with("password"){ "baz" }
+    @orig_stdout = $stdout
+    $stdout = File.open(File::NULL, 'w')
+  end
+
+  after do
+    $stdout = @orig_stdout
   end
 
   describe '#new' do
@@ -22,8 +28,9 @@ RSpec.describe ChefVault::User do
 
   describe 'decrypt_password' do
     it 'echoes warning' do
-      expect(STDOUT).to receive(:puts).with("WARNING: This method is deprecated, please switch to item['value'] calls")
-      user.decrypt_password
+      expect { user.decrypt_password }
+        .to output("WARNING: This method is deprecated, please switch to item['value'] calls\n")
+        .to_stdout
     end
 
     it 'returns items password' do


### PR DESCRIPTION
* ChefVault::Item#clients can now accept a Chef::ApiClient object instead of a search string.  Requested by @lamont-granquist to make implementing chef-vault into `knife bootstrap` easier
* allow Ruby 1.9.3 failures to not cause the overall build to fail on Travis
* switch to latest 2.0.x, 2.1.x, and 2.2.x releases of Ruby
* add --clean-unknown-clients switch to `knife vault refresh`
  * as a side effect, `ChefVault::Item` now has a `#refresh` method which can be used to programatically perform the same operation as `knife vault refresh`
* enhance 'knife vault show VAULTNAME' (without an item name) to list the names of the items in the vault for parity with 'knife data bag show'
* add #raw_keys to ChefVault::Item that calls #keys on the underlying data bag item.  We can't make ChefVault::Item work like a true hash without breaking the public API, but this at least makes it easier to get a list of keys
* allow ChefVault::Item.new and ChefVault::Item.load to specify an alternate node name and client key path.  See the README for the use case this serves.
