### PR TITLE
Only load the parts of chef we actually use

### DIFF
--- a/lib/chef-vault.rb
+++ b/lib/chef-vault.rb
@@ -16,7 +16,12 @@
 # limitations under the License.
 #
 
-require 'chef'
+require 'chef/search/query'
+require 'chef/version'
+require 'chef/config'
+require 'chef/api_client'
+require 'chef/data_bag_item'
+require 'chef/encrypted_data_bag_item'
 require 'chef/user'
 require 'chef-vault/version'
 require 'chef-vault/exceptions'


### PR DESCRIPTION
Currently, chef-vault is loading all of chef, including resources and providers and all kinds of stuff it doesn't actually need. This is triggering an issue in our ChefDK builds where `chef-provisioning` gets required (due to a dubious decision on our part) and then has dependency conflicts with `knife-windows`.

That said, minimizing the number of files required will make chef-vault run faster, which will be nice on its own.