### PR TITLE
Detect when trying to manage a v1 vault

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,55 @@
+# UPGRADING A v1 VAULT to v2
+
+chef-vault v2 added metadata to the vault to keep track of
+which secrets belong to admins and which belong to admins,
+as well as the search query to use during a `knife vault refresh`
+operation.
+
+You can use chef-vault v2 to decrypt v1 vaults, but the management
+operations are unable to intuit which of the secrets belong to
+clients and which belong to admins.  Fixing this error thus requires
+some manual intervention.
+
+If you attempt to use the management operations (refresh, update, etc.)
+on a v1 vault, you will get this error:
+
+    ChefVault::Exceptions::V1Format: cannot manage a v1 vault.  See UPGRADE.md for help
+
+To fix this, you need to edit the data bag item by hand.   Assuming a
+vault 'foo' with an item 'bar', run:
+
+    knife data bag edit foo bar_keys
+
+This will present you with a JSON representation of the extra data
+bag item managed by chef-vault.  It will have an id key as well as a key
+for every user for whom the vault item is encrypted:
+
+    {
+      "id" : "bar_keys",
+      "james" : "iWdGgm...\n",
+      "one" : "RjJ4rlh....\n",
+      "two" : "NHJlqnfd9...\n",
+      "three" : "GjXkrxq...\n"
+    }
+
+Add keys for 'admins', 'clients' and 'search_query':
+
+    {
+      "id" : "bar_keys",
+      "james" : "iWdGgm...\n",
+      "one" : "RjJ4rlh....\n",
+      "two" : "NHJlqnfd9...\n",
+      "three" : "GjXkrxq...\n",
+      "admins": [],
+      "clients": [],
+      "search_query": ""
+    }
+
+Save the edited data bag and run knife vault update with the appropriate values to populate those keys:
+
+    knife vault update foo bar -S 'name:*' -A james
+
+(set your search query to something appropriate for your environment)
+
+v2.7.0 of chef-vault may add some automation to this step, but for now this
+provides a way to upgrade without breaking your ability to manage things.

--- a/features/detect_and_warn_v1_vault.feature
+++ b/features/detect_and_warn_v1_vault.feature
@@ -1,0 +1,15 @@
+Feature: Detect and Warn for v1 Vaults
+
+  chef-vault can read a v1 vault, but the management commands
+  tend to break when they try to deference v2 fields like
+  clients and admins.  They should detect and warn when trying
+  to access a v1 vault
+
+  Scenario: Add search query to v1 vault
+    Given a local mode chef repo with nodes 'one,two,three'
+    And I create a vault item 'test/item' containing the JSON '{"foo": "bar"}' encrypted for 'one,two,three'
+    Then the vault item 'test/item' should be encrypted for 'one,two,three'
+    And 'one,two,three' should be a client for the vault item 'test/item'
+    And I downgrade the vault item 'test/item' to v1 syntax
+    And I try to add 'bob' as an admin for the vault item 'test/item'
+    Then the output should match /cannot manage a v1 vault.  See UPGRADE.md for help/

--- a/features/step_definitions/chef-vault.rb
+++ b/features/step_definitions/chef-vault.rb
@@ -99,8 +99,8 @@ Given(/^I can('t)? decrypt the vault item '(.+)\/(.+)' as '(.+)'$/) do |neg, vau
   end
 end
 
-Given(/^I add '(.+)' as an admin for the vault item '(.+)\/(.+)'$/) do |newadmin, vault, item|
-  run_simple "knife vault update #{vault} #{item} -c knife.rb -z -A #{newadmin}"
+Given(/^I (try to )?add '(.+)' as an admin for the vault item '(.+)\/(.+)'$/) do |try, newadmin, vault, item|
+  run_simple "knife vault update #{vault} #{item} -c knife.rb -z -A #{newadmin}", !try
 end
 
 Given(/^I show the keys of the vault '(.+)'$/) do |vault|
@@ -113,4 +113,12 @@ end
 
 Given(/^I check the type of the data bag item '(.+)\/(.+)'$/) do |vault, item|
   run_simple "knife vault itemtype #{vault} #{item} -c knife.rb -z"
+end
+
+Given(/^I downgrade the vault item '(.+)\/(.+)' to v1 syntax/) do |vault, item|
+  # v1 syntax doesn't have the admins, clients and search_query keys
+  keysfile = "tmp/aruba/data_bags/#{vault}/#{item}_keys.json"
+  data = JSON.parse(IO.read(keysfile))
+  %w(admins clients search_query).each { |k| data.delete(k) }
+  IO.write(keysfile, JSON.generate(data))
 end

--- a/lib/chef-vault/exceptions.rb
+++ b/lib/chef-vault/exceptions.rb
@@ -48,5 +48,8 @@ class ChefVault
 
     class IdMismatch < Exceptions
     end
+
+    class V1Format < Exceptions
+    end
   end
 end

--- a/lib/chef-vault/item_keys.rb
+++ b/lib/chef-vault/item_keys.rb
@@ -30,6 +30,10 @@ class ChefVault
     end
 
     def add(chef_client, data_bag_shared_secret, type)
+      unless @raw_data.key?(type)
+        raise ChefVault::Exceptions::V1Format,
+              'cannot manage a v1 vault.  See UPGRADE.md for help'
+      end
       public_key = OpenSSL::PKey::RSA.new chef_client.public_key
       self[chef_client.name] =
         Base64.encode64(public_key.public_encrypt(data_bag_shared_secret))


### PR DESCRIPTION
and direct people to a document describing how to manually fix the missing metadata.